### PR TITLE
Compile against Spark 1.2 by default.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ scalaVersion := "2.10.4"
 
 libraryDependencies += "org.apache.hadoop" % "hadoop-client" % "1.0.4"
 
-libraryDependencies += "org.apache.spark" %% "spark-sql" % "1.1.0"
+libraryDependencies += "org.apache.spark" %% "spark-sql" % "1.2.0"
 
 libraryDependencies += "com.google.guava" % "guava" % "14.0.1" % Test
 


### PR DESCRIPTION
There is the binary incompatible change in SQL's StructField constructor.