### PR TITLE
Add support for 'text' fields

### DIFF
--- a/src/main/scala/com/databricks/examples/redshift/input/SchemaParser.scala
+++ b/src/main/scala/com/databricks/examples/redshift/input/SchemaParser.scala
@@ -33,7 +33,7 @@ private[redshift] object SchemaParser extends JavaTokenParsers {
   private val BOOLEAN: Parser[DataType] = "boolean" ^^^ BooleanType
   private val VARCHAR: Parser[DataType] =
     ("varchar" | "character varying" | "nvarchar" | "text"
-      | "char" | "character" | "nchar" | "bpchar") ~ "(" ~ decimalNumber ~ ")" ^^^ StringType
+      | "char" | "character" | "nchar" | "bpchar") ~ (("(" ~ decimalNumber ~ ")") | "") ^^^ StringType
   private val DATE: Parser[DataType] = "date" ^^^ DateType
   private val TIMESTAMP: Parser[DataType] = ("timestamp" | "timestamp without time zone") ^^^ TimestampType
 


### PR DESCRIPTION
Currently, spark-redshift assumes all text types are followed by the length in parens. The length is not required for redshift types, so I made it optional.