### PR TITLE
Allow the user to specify hadoop config

### DIFF
--- a/src/main/scala/com/databricks/examples/redshift/input/RedshiftInputFormat.scala
+++ b/src/main/scala/com/databricks/examples/redshift/input/RedshiftInputFormat.scala
@@ -82,7 +82,7 @@ object RedshiftInputFormat {
    */
   class SQLContextWithRedshiftFile(sqlContext: SQLContext) {
 
-    def defaultConf: Configuration = sqlContext.sparkContext.hadoopConfiguration
+    val defaultConf: Configuration = sqlContext.sparkContext.hadoopConfiguration
 
     /**
      * Read a file unloaded from Redshift into a SchemaRDD.


### PR DESCRIPTION
Allow the consumers of the `redshiftFile` to specify a Hadoop config (for example, to specify a custom delimiter).
The new config parameter is optional and the old interface works as it did before.