### PR TITLE
Exclude hadoop-core from build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ scalaVersion := "2.10.4"
 
 libraryDependencies += "org.apache.hadoop" % "hadoop-client" % "1.0.4"
 
-libraryDependencies += "org.apache.spark" %% "spark-sql" % "1.2.0"
+libraryDependencies += "org.apache.spark" %% "spark-sql" % "1.2.0" exclude ("org.apache.hadoop", "hadoop-client")
 
 libraryDependencies += "com.google.guava" % "guava" % "14.0.1" % Test
 


### PR DESCRIPTION
Otherwise we always pull in 2.2.0 from spark 1.2