### PR TITLE
Refactor spark-redshift

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Hadoop input format for Redshift tables unloaded with the ESCAPE option.
 
 Usage in Spark Core:
 ```scala
-import com.databricks.examples.redshift.input.RedshiftInputFormat
+import com.databricks.spark.redshift.RedshiftInputFormat
 
 val records = sc.newAPIHadoopFile(
   path,
@@ -16,8 +16,11 @@ val records = sc.newAPIHadoopFile(
 
 Usage in Spark SQL:
 ```scala
-import com.databricks.examples.redshift.input.RedshiftInputFormat._
+import com.databricks.spark.redshift._
 
 // Call redshiftFile() that returns a SchemaRDD with all string columns.
-val records: SchemaRDD = sqlContext.redshiftFile(path, Seq("name", "age"))
+val records: DataFrame = sqlContext.redshiftFile(path, Seq("name", "age"))
+
+// Call redshiftFile() with the table schema.
+val records: DataFrame = sqlContext.redshiftFile(path, "name varchar(10) age integer")
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ organization := "com.databricks"
 
 name := "spark-redshift"
 
-version := "0.1"
+version := "0.3"
 
 scalaVersion := "2.10.4"
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 net.virtualvoid.sbt.graph.Plugin.graphSettings
 
-organization := "com.databricks.examples.redshift"
+organization := "com.databricks"
 
-name := "redshift-input-format"
+name := "spark-redshift"
 
 version := "0.1"
 

--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,10 @@ spName := "databricks/spark-redshift"
 
 sparkComponents += "sql"
 
+licenses += "Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0")
+
+credentials += Credentials(Path.userHome / ".ivy2" / ".credentials")
+
 libraryDependencies := libraryDependencies.value.map { module =>
   if (module.name.indexOf("spark-sql") >= 0) {
     module.exclude("org.apache.hadoop", "hadoop-client")

--- a/src/main/scala/com/databricks/spark/redshift/SchemaParser.scala
+++ b/src/main/scala/com/databricks/spark/redshift/SchemaParser.scala
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
-package com.databricks.examples.redshift.input
+package com.databricks.spark.redshift
 
-import scala.language.implicitConversions
 import scala.util.parsing.combinator._
 
-import org.apache.spark.sql._
 import org.apache.spark.sql.types._
 
+/**
+ * A simple parser for Redshift table schemas.
+ */
 private[redshift] object SchemaParser extends JavaTokenParsers {
   // redshift data types: http://docs.aws.amazon.com/redshift/latest/dg/c_Supported_data_types.html
   private val SMALLINT: Parser[DataType] = ("smallint" | "int2") ^^^ ShortType

--- a/src/main/scala/com/databricks/spark/redshift/package.scala
+++ b/src/main/scala/com/databricks/spark/redshift/package.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2015 Databricks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.databricks.spark
+
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.{StringType, StructField, StructType}
+import org.apache.spark.sql.{DataFrame, Row, SQLContext}
+
+package object redshift {
+
+  /**
+   * Wrapper of SQLContext that provide `redshiftFile` method.
+   */
+  implicit class RedshiftContext(sqlContext: SQLContext) {
+
+    /**
+     * Read a file unloaded from Redshift into a DataFrame.
+     * @param path input path
+     * @return a DataFrame with all string columns
+     */
+    def redshiftFile(path: String, columns: Seq[String]): DataFrame = {
+      val sc = sqlContext.sparkContext
+      val rdd = sc.newAPIHadoopFile(path, classOf[RedshiftInputFormat],
+        classOf[java.lang.Long], classOf[Array[String]], sc.hadoopConfiguration)
+      // TODO: allow setting NULL string.
+      val nullable = rdd.values.map(_.map(f => if (f.isEmpty) null else f)).map(x => Row(x: _*))
+      val schema = StructType(columns.map(c => StructField(c, StringType, nullable = true)))
+      sqlContext.createDataFrame(nullable, schema)
+    }
+
+    /**
+     * Reads a table unload from Redshift with its schema in format "name0 type0 name1 type1 ...".
+     */
+    def redshiftFile(path: String, schema: String): DataFrame = {
+      val structType = SchemaParser.parseSchema(schema)
+      val casts = structType.fields.map { field =>
+        col(field.name).cast(field.dataType).as(field.name)
+      }
+      redshiftFile(path, structType.fieldNames).select(casts: _*)
+    }
+  }
+}

--- a/src/test/scala/com/databricks/spark/redshift/RedshiftInputFormatSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/RedshiftInputFormatSuite.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.databricks.examples.redshift.input
+package com.databricks.spark.redshift
 
 import java.io.{DataOutputStream, File, FileOutputStream}
 
@@ -24,15 +24,14 @@ import org.apache.hadoop.conf.Configuration
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
 
 import org.apache.spark.SparkContext
-import org.apache.spark.SparkContext._
-import org.apache.spark.sql._
+import org.apache.spark.sql.{SQLContext, Row}
 import org.apache.spark.sql.types._
 
-import com.databricks.examples.redshift.input.RedshiftInputFormat._
+import com.databricks.spark.redshift.RedshiftInputFormat._
 
 class RedshiftInputFormatSuite extends FunSuite with BeforeAndAfterAll {
 
-  import com.databricks.examples.redshift.input.RedshiftInputFormatSuite._
+  import RedshiftInputFormatSuite._
 
   private var sc: SparkContext = _
 


### PR DESCRIPTION
to make it more like spark-avro and spark-csv. No implementation change in this PR.

1. The package is renamed to `com.databricks.spark.redshift` from `com.databricks.examples.redshift.input`.
2. The implicit `redshiftFile` is now under `com.databricks.spark.redshift`.
3. README is updated.
4. Rename `SchemaRDD` to `DataFrame`.
5. Add more Spark Packages settings in `build.sbt`.

@brkyvz 