### PR TITLE
Integrate code coverage metrics using codecov.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,6 @@ env:
   - HADOOP_VERSION="1.2.1"
   - HADOOP_VERSION="2.2.0"
 script:
-  - sbt -Dhadoop.version=$HADOOP_VERSION test
+  - sbt -Dhadoop.version=$HADOOP_VERSION coverage test
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 RedshiftInputFormat
 ===
 
+[![Build Status](https://travis-ci.org/databricks/spark-redshift.svg?branch=master)](https://travis-ci.org/databricks/spark-redshift)
+[![codecov.io](http://codecov.io/github/databricks/spark-redshift/coverage.svg?branch=master)](http://codecov.io/github/databricks/spark-redshift?branch=master)
+
 Install
 -------
 

--- a/build.sbt
+++ b/build.sbt
@@ -35,3 +35,8 @@ libraryDependencies += "org.apache.hadoop" % "hadoop-client" % hadoopVersion.val
 libraryDependencies += "com.google.guava" % "guava" % "14.0.1" % Test
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.1.5" % Test
+
+ScoverageSbtPlugin.ScoverageKeys.coverageHighlighting := {
+  if (scalaBinaryVersion.value == "2.10") false
+  else false
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,3 +5,5 @@ addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.4")
 resolvers += "Spark Package Main Repo" at "https://dl.bintray.com/spark-packages/maven"
 
 addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.0")
+
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.1.0")


### PR DESCRIPTION
This PR integrates code coverage into our build using Scoverage and http://codecov.io.

After this PR is merged, you should be able to view coverage metrics at https://codecov.io/github/databricks/spark-redshift or in GitHub by using the Codecov browser plugin.