### PR TITLE
Fix overwrite mode for nonexistent table

### DIFF
--- a/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
@@ -73,7 +73,9 @@ class RedshiftWriter(jdbcWrapper: JDBCWrapper) extends Logging {
       log.info("Existing data will be backed up in: " + backupTable)
 
       action(tempTable)
-      conn.prepareStatement(s"ALTER TABLE ${params.table} RENAME TO $backupTable").execute()
+      if (jdbcWrapper.tableExists(conn, params.table)) {
+        conn.prepareStatement(s"ALTER TABLE ${params.table} RENAME TO $backupTable").execute()
+      }
       conn.prepareStatement(s"ALTER TABLE $tempTable RENAME TO ${params.table}").execute()
     } catch {
       case e: SQLException =>
@@ -86,7 +88,7 @@ class RedshiftWriter(jdbcWrapper: JDBCWrapper) extends Logging {
         throw new Exception("Error loading data to Redshift, changes reverted.", e)
     }
 
-    conn.prepareStatement(s"DROP TABLE $backupTable").execute()
+    conn.prepareStatement(s"DROP TABLE IF EXISTS $backupTable").execute()
   }
 
   /**

--- a/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
@@ -256,7 +256,7 @@ class RedshiftSourceSuite
           "GRANT SELECT ON test_table_staging.+ TO jeremy".r,
           "ALTER TABLE test_table RENAME TO test_table_backup_.*".r,
           "ALTER TABLE test_table_staging_.* RENAME TO test_table".r,
-          "DROP TABLE test_table_backup.*".r)
+          "DROP TABLE IF EXISTS test_table_backup.*".r)
 
     val jdbcWrapper = mockJdbcWrapper(jdbcUrl, expectedCommands)
 


### PR DESCRIPTION
If the write mode is set to `overwrite`, loading will fail if the target table does not already exist, when it tries to rename it to the backup table.
This only tries to create the backup table if the target table already exists, and only drops the backup table if it was created.