### PR TITLE
Option to enable Avro compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ val sqlContext = new SQLContext(sc)
 // Get some data from a Redshift table
 val df: DataFrame = sqlContext.read
     .format("com.databricks.spark.redshift")
-    .option("url", "jdbc:postgresql://redshifthost:5439/database?user=username&password=pass")
+    .option("url", "jdbc:redshift://redshifthost:5439/database?user=username&password=pass")
     .option("dbtable", "my_table")
     .option("tempdir", "s3://path/for/temp/data")
     .load()
@@ -60,7 +60,7 @@ val df: DataFrame = sqlContext.read
 
 df.write
     .format("com.databricks.spark.redshift")
-    .option("url", "jdbc:postgresql://redshifthost:5439/database?user=username&password=pass")
+    .option("url", "jdbc:redshift://redshifthost:5439/database?user=username&password=pass")
     .option("dbtable", "my_table_copy")
     .option("tempdir", "s3://path/for/temp/data")
     .option("avrocompression", "snappy")
@@ -79,7 +79,7 @@ sql_context = SQLContext(sc)
 # Read data from a table
 df = sql_context.read \
     .format("com.databricks.spark.redshift") \
-    .option("url", "jdbc:postgresql://redshifthost:5439/database?user=username&password=pass") \
+    .option("url", "jdbc:redshift://redshifthost:5439/database?user=username&password=pass") \
     .option("dbtable", "my_table") \
     .option("tempdir", "s3://path/for/temp/data") \
     .load()
@@ -87,7 +87,7 @@ df = sql_context.read \
 # Write back to a table
 df.write \
     .format("com.databricks.spark.redshift")
-    .option("url", "jdbc:postgresql://redshifthost:5439/database?user=username&password=pass") \
+    .option("url", "jdbc:redshift://redshifthost:5439/database?user=username&password=pass") \
     .option("dbtable", "my_table_copy") \
     .option("tempdir", "s3://path/for/temp/data") \
     .option("avrocompression", "snappy")
@@ -103,7 +103,7 @@ USING com.databricks.spark.redshift
 OPTIONS (dbtable 'my_table',
          tempdir 's3://my_bucket/tmp',
          avrocompression 'snappy',
-         url 'jdbc:postgresql://host:port/db?user=username&password=pass');
+         url 'jdbc:redshift://host:port/db?user=username&password=pass');
 ```
 
 ### Scala helper functions

--- a/README.md
+++ b/README.md
@@ -279,6 +279,16 @@ It may be useful to have some <tt>GRANT</tt> commands or similar run here when l
 table, the changes will be reverted and the backup table restored if post actions fail.</p>
     </td>
  </tr>
+ <tr>
+    <td><tt>avrocompression</tt></td>
+    <td>No</td>
+    <td><tt>snappy</tt></td>
+    <td>
+<p>Sets the compression codec to use on the Avro data to be loaded into Redshift. This overwrites the <tt>avro.output.codec</tt>
+key in the Hadoop configuration with the specified value. To disable this and use the value set in the Hadoop configuration,
+set this to null or an empty string.</p>
+    </td>
+ </tr>
 </table>
 
 ## AWS Credentials

--- a/README.md
+++ b/README.md
@@ -291,6 +291,13 @@ table, the changes will be reverted and the backup table restored if post action
 key in the Hadoop configuration with the specified value and also sets <tt>mapred.output.compress = true</tt> and
 <tt>mapred.output.compression.type = BLOCK</tt>. If left unset (or set to null or an empty string) it will leave
 the Hadoop configuration unchanged.</p>
+<p>Valid settings are:</p>
+<ul>
+    <li><tt>""</tt> (default): use compression settings from Hadoop config (usually none unless explicitly set).</li>
+    <li><tt>"snappy"</tt>: use snappy compression.</li>
+    <li><tt>"deflate"</tt>: use deflate (zlib) compression (better ratio but more CPU intensive than snappy).</li>
+    <li><tt>"null"</tt>: disable compression.</li>
+</ul>
     </td>
  </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -288,7 +288,8 @@ table, the changes will be reverted and the backup table restored if post action
     <td>No compression (unless set in Hadoop config)</td>
     <td>
 <p>Sets the compression codec to use on the Avro data to be loaded into Redshift. This overwrites the <tt>avro.output.codec</tt>
-key in the Hadoop configuration with the specified value. If left unset (or set to null or an empty string) it will leave
+key in the Hadoop configuration with the specified value and also sets <tt>mapred.output.compress = true</tt> and
+<tt>mapred.output.compression.type = BLOCK</tt>. If left unset (or set to null or an empty string) it will leave
 the Hadoop configuration unchanged.</p>
     </td>
  </tr>

--- a/README.md
+++ b/README.md
@@ -50,21 +50,22 @@ val sqlContext = new SQLContext(sc)
 // Get some data from a Redshift table
 val df: DataFrame = sqlContext.read
     .format("com.databricks.spark.redshift")
-    .option("url", "jdbc:redshift://redshifthost:5439/database?user=username&password=pass")
-    .option("dbtable" -> "my_table")
-    .option("tempdir" -> "s3://path/for/temp/data")
+    .option("url", "jdbc:postgresql://redshifthost:5439/database?user=username&password=pass")
+    .option("dbtable", "my_table")
+    .option("tempdir", "s3://path/for/temp/data")
     .load()
 
 // Apply some transformations to the data as per normal, then you can use the
 // Data Source API to write the data back to another table
 
 df.write
-  .format("com.databricks.spark.redshift")
-    .option("url", "jdbc:redshift://redshifthost:5439/database?user=username&password=pass")
-    .option("dbtable" -> "my_table_copy")
-    .option("tempdir" -> "s3://path/for/temp/data")
-  .mode("error")
-  .save()
+    .format("com.databricks.spark.redshift")
+    .option("url", "jdbc:postgresql://redshifthost:5439/database?user=username&password=pass")
+    .option("dbtable", "my_table_copy")
+    .option("tempdir", "s3://path/for/temp/data")
+    .option("avrocompression", "snappy")
+    .mode("error")
+    .save()
 ```
 
 #### Python
@@ -78,19 +79,20 @@ sql_context = SQLContext(sc)
 # Read data from a table
 df = sql_context.read \
     .format("com.databricks.spark.redshift") \
-    .option("url", "jdbc:redshift://redshifthost:5439/database?user=username&password=pass") \
-    .option("dbtable" -> "my_table") \
-    .option("tempdir" -> "s3://path/for/temp/data") \
+    .option("url", "jdbc:postgresql://redshifthost:5439/database?user=username&password=pass") \
+    .option("dbtable", "my_table") \
+    .option("tempdir", "s3://path/for/temp/data") \
     .load()
 
 # Write back to a table
 df.write \
-  .format("com.databricks.spark.redshift")
-  .option("url", "jdbc:redshift://redshifthost:5439/database?user=username&password=pass") \
-  .option("dbtable" -> "my_table_copy") \
-  .option("tempdir" -> "s3://path/for/temp/data") \
-  .mode("error")
-  .save()
+    .format("com.databricks.spark.redshift")
+    .option("url", "jdbc:postgresql://redshifthost:5439/database?user=username&password=pass") \
+    .option("dbtable", "my_table_copy") \
+    .option("tempdir", "s3://path/for/temp/data") \
+    .option("avrocompression", "snappy")
+    .mode("error")
+    .save()
 ```
 
 #### SQL
@@ -100,7 +102,8 @@ CREATE TABLE my_table
 USING com.databricks.spark.redshift
 OPTIONS (dbtable 'my_table',
          tempdir 's3://my_bucket/tmp',
-         url 'jdbc:redshift://host:port/db?user=username&password=pass');
+         avrocompression 'snappy',
+         url 'jdbc:postgresql://host:port/db?user=username&password=pass');
 ```
 
 ### Scala helper functions
@@ -282,11 +285,11 @@ table, the changes will be reverted and the backup table restored if post action
  <tr>
     <td><tt>avrocompression</tt></td>
     <td>No</td>
-    <td><tt>snappy</tt></td>
+    <td>No compression (unless set in Hadoop config)</td>
     <td>
 <p>Sets the compression codec to use on the Avro data to be loaded into Redshift. This overwrites the <tt>avro.output.codec</tt>
-key in the Hadoop configuration with the specified value. To disable this and use the value set in the Hadoop configuration,
-set this to null or an empty string.</p>
+key in the Hadoop configuration with the specified value. If left unset (or set to null or an empty string) it will leave
+the Hadoop configuration unchanged.</p>
     </td>
  </tr>
 </table>

--- a/src/it/scala/com/databricks/spark/redshift/CompressionIntegrationSuite.scala
+++ b/src/it/scala/com/databricks/spark/redshift/CompressionIntegrationSuite.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2015 TouchType Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.databricks.spark.redshift
+
+import org.apache.spark.sql.{Row, SaveMode}
+import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
+
+/**
+  * End-to-end tests for loading/unloading data from Redshift using Avro
+  * compression.
+  */
+class CompressionIntegrationSuite extends IntegrationSuiteBase {
+
+  test("roundtrip save and load with Avro snappy compression") {
+    val tableName = s"roundtrip_save_and_load$randomSuffix"
+    val df = sqlContext.createDataFrame(sc.parallelize(Seq(Row(1))),
+      StructType(StructField("a", IntegerType) :: Nil))
+    try {
+      df.write
+        .format("com.databricks.spark.redshift")
+        .option("url", jdbcUrl)
+        .option("dbtable", tableName)
+        .option("tempdir", tempDir)
+        .option("avrocompression", "snappy")
+        .mode(SaveMode.ErrorIfExists)
+        .save()
+
+      assert(DefaultJDBCWrapper.tableExists(conn, tableName))
+      val loadedDf = sqlContext.read
+        .format("com.databricks.spark.redshift")
+        .option("url", jdbcUrl)
+        .option("dbtable", tableName)
+        .option("tempdir", tempDir)
+        .option("avrocompression", "snappy")
+        .load()
+      assert(loadedDf.schema.length === 1)
+      assert(loadedDf.columns === Seq("a"))
+      checkAnswer(loadedDf, Seq(Row(1)))
+    } finally {
+      conn.prepareStatement(s"drop table if exists $tableName").executeUpdate()
+      conn.commit()
+    }
+  }
+
+  test("roundtrip save and load with Avro deflate compression") {
+    val tableName = s"roundtrip_save_and_load$randomSuffix"
+    val df = sqlContext.createDataFrame(sc.parallelize(Seq(Row(1))),
+      StructType(StructField("a", IntegerType) :: Nil))
+    try {
+      df.write
+        .format("com.databricks.spark.redshift")
+        .option("url", jdbcUrl)
+        .option("dbtable", tableName)
+        .option("tempdir", tempDir)
+        .option("avrocompression", "deflate")
+        .mode(SaveMode.ErrorIfExists)
+        .save()
+
+      assert(DefaultJDBCWrapper.tableExists(conn, tableName))
+      val loadedDf = sqlContext.read
+        .format("com.databricks.spark.redshift")
+        .option("url", jdbcUrl)
+        .option("dbtable", tableName)
+        .option("tempdir", tempDir)
+        .option("avrocompression", "deflate")
+        .load()
+      assert(loadedDf.schema.length === 1)
+      assert(loadedDf.columns === Seq("a"))
+      checkAnswer(loadedDf, Seq(Row(1)))
+    } finally {
+      conn.prepareStatement(s"drop table if exists $tableName").executeUpdate()
+      conn.commit()
+    }
+  }
+}

--- a/src/main/scala/com/databricks/spark/redshift/Parameters.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Parameters.scala
@@ -39,7 +39,8 @@ private[redshift] object Parameters extends Logging {
     "overwrite" -> "false",
     "diststyle" -> "EVEN",
     "usestagingtable" -> "true",
-    "postactions" -> ";"
+    "postactions" -> ";",
+    "avrocompression" -> "snappy"
   )
 
   /**
@@ -210,5 +211,12 @@ private[redshift] object Parameters extends Logging {
         credentials
       }
     }
+
+    /**
+     * When nonempty/non-null sets the compression codec to use for writing Avro data.
+     *
+     * Defaults to snappy.
+     */
+    def avrocompression = parameters("avrocompression")
   }
 }

--- a/src/main/scala/com/databricks/spark/redshift/Parameters.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Parameters.scala
@@ -215,7 +215,7 @@ private[redshift] object Parameters extends Logging {
     /**
      * When nonempty/non-null sets the compression codec to use for writing Avro data.
      *
-     * Defaults to snappy.
+     * Defaults to disabled (i.e. whatever is set in Hadoop config).
      */
     def avrocompression = parameters("avrocompression")
   }

--- a/src/main/scala/com/databricks/spark/redshift/Parameters.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Parameters.scala
@@ -40,7 +40,7 @@ private[redshift] object Parameters extends Logging {
     "diststyle" -> "EVEN",
     "usestagingtable" -> "true",
     "postactions" -> ";",
-    "avrocompression" -> "snappy"
+    "avrocompression" -> ""
   )
 
   /**

--- a/src/main/scala/com/databricks/spark/redshift/Parameters.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Parameters.scala
@@ -217,6 +217,6 @@ private[redshift] object Parameters extends Logging {
      *
      * Defaults to disabled (i.e. whatever is set in Hadoop config).
      */
-    def avrocompression = parameters("avrocompression")
+    def avrocompression: String = parameters("avrocompression")
   }
 }

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
@@ -180,6 +180,12 @@ class RedshiftWriter(jdbcWrapper: JDBCWrapper) extends Logging {
   def saveToRedshift(sqlContext: SQLContext, data: DataFrame, params: MergedParameters) : Unit = {
     val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl, new Properties()).apply()
 
+    if (params.avrocompression != null && params.avrocompression.nonEmpty) {
+      val conf = sqlContext.sparkContext.hadoopConfiguration
+      conf.set("mapred.output.compress", "true")
+      conf.set("mapred.output.compression.type", "BLOCK")
+      conf.set("avro.output.codec", params.avrocompression)
+    }
     try {
       if (params.overwrite && params.useStagingTable) {
         withStagingTable(conn, params, table => {

--- a/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
@@ -274,17 +274,11 @@ class RedshiftSourceSuite
 
   test("DefaultSource serializes data as Avro when avrocompression is enabled") {
 
-    //val testSqlContext = new SQLContext(sc)
-
-    //val jdbcUrl = "jdbc:postgresql://foo/bar"
     val params = defaultParams ++ Map(
       "postactions" -> "GRANT SELECT ON %s TO jeremy",
       "diststyle" -> "KEY",
       "distkey" -> "testInt",
       "avrocompression" -> "snappy")
-
-    //val rdd = sc.parallelize(TestUtils.expectedData.toSeq)
-    //val df = testSqlContext.createDataFrame(rdd, TestUtils.testSchema)
 
     val expectedCommands =
       Seq("DROP TABLE IF EXISTS test_table_staging_.*".r,


### PR DESCRIPTION
I've added an option to enable compression on the Avro data loaded into Redshift. I haven't benchmarked it but it does seem that it can have a quite significant impact on performance (a small Spark job with the output loaded into Redshift went from ~5 minutes to ~4 minutes when I enabled snappy compression, and roughly half of that run time was on the Spark job itself).
Ideally setting snappy compression by default would be nice, as it should be available everywhere so it's basically a free performance boost. But enabling it involves modifying the Hadoop configuration, which could possibly interact subtly with other parts of the user's job and lead to hard to diagnose issues down the line.
So I've left it disabled by default, but included it in the examples so that it is easier to find.
I also cleaned up a couple of typos in the README examples while I was modifying it.