### PR TITLE
Calculate `VARCHAR(N)` on schema generation to support text longer than the 256 characters

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,6 +41,8 @@ libraryDependencies += "com.google.guava" % "guava" % "14.0.1" % Test
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.1.5" % Test
 
+libraryDependencies += "org.apache.commons" % "commons-csv" % "1.1"
+
 libraryDependencies += "org.scalamock" %% "scalamock-scalatest-support" % "3.2" % Test
 
 ScoverageSbtPlugin.ScoverageKeys.coverageHighlighting := {

--- a/src/main/scala/com/databricks/spark/redshift/Conversions.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Conversions.scala
@@ -129,9 +129,11 @@ private[redshift] object Conversions {
   }
 
   def mapStrLengths(df:DataFrame) : Map[String, Int] = {
+    val schema:StructType = df.schema
+
     // Calculate maximum string lengths for each row in each respective row
     val stringLengths = df.flatMap(row =>
-      df.schema collect {
+      schema.collect {
         case StructField(columnName, StringType, _, _) => (columnName, getStrLength(row, columnName))
       }
     ).reduceByKey(Math.max(_, _))

--- a/src/main/scala/com/databricks/spark/redshift/Conversions.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Conversions.scala
@@ -35,11 +35,28 @@ private object RedshiftBooleanParser extends JavaTokenParsers {
   def parseRedshiftBoolean(s: String): Boolean = parse(TRUE | FALSE, s).get
 }
 
-object StringMetaSchema {
-  def mapStrLengths(df:DataFrame) : Map[String, Int] = {
+/**
+ * Utility methods responsible for extracting information from data contained within dataframe in order to generate
+ * a schema compatible with Redshift.
+ */
+object MetaSchema {
+  /**
+   * Map-Reduce task to calculate the longest string length for each row, in each string column in the dataframe.
+   *
+   * Note: This is used to generate N for the VARCHAR(N) field in the table schema to be loaded into Redshift.
+   *
+   * TODO: This should only be called once per load into Redshift. A cache, TraversableOnce, or some similar
+   *   structure should be used to enforce this function only being called once.
+   *
+   * @param df DataFrame to be processed
+   * @return A Map[String, Int] representing an assocition between the column name and the length of that column's
+   *         longest string
+   */
+  private[redshift] def mapStrLengths(df:DataFrame) : Map[String, Int] = {
     val schema:StructType = df.schema
 
-    // Calculate maximum string lengths for each row in each respective row
+    // For each row, filter the string columns and calculate the string length
+    // TODO: Other optimization strategies may be possible
     val stringLengths = df.flatMap(row =>
       schema.collect {
         case StructField(columnName, StringType, _, _) => (columnName, getStrLength(row, columnName))
@@ -49,24 +66,43 @@ object StringMetaSchema {
     stringLengths.collect().toMap
   }
 
-  def getStrLength(row:Row, columnName:String): Int = {
+  /**
+   * Calculate the string length in columnName for the provided Row. Defensively returns 0 if the provided
+   * columnName is not a string column.
+   *
+   * This is a collaborator method to make the mapStrLengths function more readable, and should not be used elsewhere.
+   *
+   * @param row Reference to a row of a dataframe
+   * @param columnName Name of the column
+   * @return Length of the string in cell, falling back to 0 if null or no string is present.
+   */
+  private[redshift] def getStrLength(row:Row, columnName:String): Int = {
     row.getAs[String](columnName) match {
       case field:String => field.length()
       case _ => 0
     }
   }
 
-  def setStrLength(metadata:Metadata, length:Int) : Metadata = {
+  /**
+   * Adds a "maxLength" -> Int field to column metadata.
+   *
+   * @param metadata metadata for a dataframe column
+   * @param length Length limit for content within that column
+   * @return new metadata object with added field
+   */
+  private[redshift] def setStrLength(metadata:Metadata, length:Int) : Metadata = {
     new MetadataBuilder().withMetadata(metadata).putLong("maxLength", length).build()
   }
 
   /**
    * Iterate through each column in the schema that is a string, storing the longest string length in that columns'
-   * metadata.
+   * metadata for later usage.
    */
   def computeEnhancedDf(df: DataFrame): DataFrame = {
+    // 1. Perform a full scan of each string column, storing it's maximum string length within a Map
     val stringLengthsByColumn = mapStrLengths(df)
 
+    // 2. Generate an enhanced schema, with the metadata for each string column
     val enhancedSchema = StructType(
       df.schema map {
         case StructField(name, StringType, nullable, meta) =>
@@ -75,7 +111,7 @@ object StringMetaSchema {
       }
     )
 
-    // Construct a new dataframe with a schema containing metadata with string lengths
+    // 3. Construct a new dataframe with a schema containing metadata with string lengths
     df.sqlContext.createDataFrame(df.rdd, enhancedSchema)
   }
 }

--- a/src/main/scala/com/databricks/spark/redshift/Conversions.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Conversions.scala
@@ -151,7 +151,7 @@ private[redshift] object Conversions {
   def setStrLength(metadata:Metadata, length:Int) : Metadata = {
     new MetadataBuilder()
       .withMetadata(metadata)
-      .putDouble("maxLength", length)
+      .putLong("maxLength", length)
       .build()
   }
 

--- a/src/main/scala/com/databricks/spark/redshift/Parameters.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Parameters.scala
@@ -163,6 +163,21 @@ private [redshift] object Parameters extends Logging {
     def postActions = parameters("postactions").split(";")
 
     /**
+     * How the maximum length for each column containing text is to be inferred (i.e. the 'N' in VARCHAR(N)).
+     * Redshift doesn't support variable length TEXT like other SQL dialects, so columns containing text of unbounded
+     * length must either be processed to determine the longest possible string in all rows for that column, or truncated
+     * to a fixed amount. A number may also be passed to this parameter allowing for the maximum number of characters.
+     *
+     * Examples:
+     *    AUTO
+     *    TRUNCATE(50)
+     *    MAXLENGTH(4096)
+     *
+     * Defaults to 'AUTO'
+     */
+    def stringLengths = parameters("stringlengths").toString().toUpperCase()
+
+    /**
      * Looks up "aws_access_key_id" and "aws_secret_access_key" in the parameter map
      * and generates a credentials string for Redshift. If no credentials have been provided,
      * this function will instead try using the Hadoop Configuration fs.* settings for the provided tempDir

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
@@ -35,11 +35,11 @@ import org.apache.spark.sql.{DataFrame, SQLContext}
 class RedshiftWriter(jdbcWrapper: JDBCWrapper) extends Logging {
 
   def varcharStr(meta: Metadata): String = {
+    // TODO: Need fallback for max length
     val maxLength: Long = meta.getLong("maxLength")
 
     maxLength match {
       case _: Long => s"VARCHAR($maxLength)"
-      case _ => "VARCHAR(255)"
     }
   }
 
@@ -79,7 +79,7 @@ class RedshiftWriter(jdbcWrapper: JDBCWrapper) extends Logging {
    * Generate CREATE TABLE statement for Redshift
    */
   def createTableSql(data: DataFrame, params: MergedParameters): String = {
-    var schemaSql = schemaString(StringMetaSchema.computeEnhancedDf(data))
+    var schemaSql = schemaString(MetaSchema.computeEnhancedDf(data))
 
     val distStyleDef = params.distStyle match {
       case Some(style) => s"DISTSTYLE $style"
@@ -91,7 +91,7 @@ class RedshiftWriter(jdbcWrapper: JDBCWrapper) extends Logging {
     }
     val sortKeyDef = params.sortKeySpec.getOrElse("")
 
-    s"CREATE TABLE IF NOT EXISTS ${params.table} ($schemaSql) $distStyleDef $distKeyDef $sortKeyDef"
+    s"CREATE TABLE IF NOT EXISTS ${params.table} ($schemaSql) $distStyleDef $distKeyDef $sortKeyDef".trim
   }
 
   /**

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
@@ -124,7 +124,9 @@ class RedshiftWriter(jdbcWrapper: JDBCWrapper) extends Logging {
    * Serialize temporary data to S3, ready for Redshift COPY
    */
   def unloadData(sqlContext: SQLContext, data: DataFrame, tempPath: String): Unit = {
-    Conversions.datesToTimestamps(sqlContext, data).write.format("com.databricks.spark.avro").save(tempPath)
+    val enrichedData = Conversions.datesToTimestamps(sqlContext, data) // TODO .extractStringColumnLengths
+
+    enrichedData.write.format("com.databricks.spark.avro").save(tempPath)
   }
 
   /**

--- a/src/test/scala/com/databricks/spark/redshift/ConversionsSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/ConversionsSuite.scala
@@ -25,9 +25,9 @@ import org.apache.spark.sql.Row
 /**
  * Unit test for data type conversions
  */
-class ConversionsSuite extends FunSuite {
+class ConversionsSuite extends MockDatabaseSuite {
 
-  val convertRow = Conversions.rowConverter(TestUtils.testSchema)
+  val convertRow = Conversions.rowConverter(testSchema)
 
   test("Data should be correctly converted") {
     val doubleMin = Double.MinValue.toString
@@ -51,7 +51,7 @@ class ConversionsSuite extends FunSuite {
   }
 
   test("Row conversion handles null values") {
-    val emptyRow = List.fill(TestUtils.testSchema.length)(null).toArray[String]
+    val emptyRow = List.fill(testSchema.length)(null).toArray[String]
     assert(convertRow(emptyRow) == Row(emptyRow: _*))
   }
 }

--- a/src/test/scala/com/databricks/spark/redshift/MockDatabaseSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/MockDatabaseSuite.scala
@@ -1,6 +1,6 @@
 package com.databricks.spark.redshift
 
-import java.sql.{PreparedStatement, Connection}
+import java.sql.{SQLException, PreparedStatement, Connection}
 
 import com.databricks.spark.redshift.TestUtils._
 import org.apache.spark.sql.jdbc.JDBCWrapper
@@ -11,6 +11,33 @@ import org.scalatest.FunSuite
 import scala.util.matching.Regex
 
 class MockDatabaseSuite extends FunSuite with MockFactory {
+  def successfulStatement(pattern: Regex): PreparedStatement = {
+    val mockedConnection = mock[Connection]
+
+    val mockedStatement = mock[PreparedStatement]
+    (mockedConnection.prepareStatement(_: String))
+      .expects(where {(sql: String) => pattern.findFirstMatchIn(sql).nonEmpty})
+      .returning(mockedStatement)
+    (mockedStatement.execute _).expects().returning(true)
+
+    mockedStatement
+  }
+
+  def failedStatement(pattern: Regex) : PreparedStatement = {
+    val mockedConnection = mock[Connection]
+
+    val mockedStatement = mock[PreparedStatement]
+    (mockedConnection.prepareStatement(_: String))
+      .expects(where {(sql: String) => pattern.findFirstMatchIn(sql).nonEmpty})
+      .returning(mockedStatement)
+
+    (mockedStatement.execute _)
+      .expects()
+      .throwing(new SQLException("Mocked Error"))
+
+    mockedStatement
+  }
+
   /**
    * Set up a mocked JDBCWrapper instance that expects a sequence of queries matching the given
    * regular expressions will be executed, and that the connection returned will be closed.
@@ -32,6 +59,26 @@ class MockDatabaseSuite extends FunSuite with MockFactory {
 
       (mockedConnection.close _).expects()
     }
+
+    jdbcWrapper
+  }
+
+  /**
+   * Prepare the JDBC wrapper for an UNLOAD test.
+   */
+  def prepareUnloadTest(params: Map[String, String]) = {
+    val jdbcUrl = params("url")
+    val jdbcWrapper = mockJdbcWrapper(jdbcUrl, Seq("UNLOAD.*".r))
+
+    // We expect some extra calls to the JDBC wrapper,
+    // to register the driver and retrieve the schema.
+    (jdbcWrapper.registerDriver _)
+      .expects(*)
+      .anyNumberOfTimes()
+    (jdbcWrapper.resolveTable _)
+      .expects(jdbcUrl, "test_table", *)
+      .returning(TestUtils.testSchema)
+      .anyNumberOfTimes()
 
     jdbcWrapper
   }

--- a/src/test/scala/com/databricks/spark/redshift/MockDatabaseSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/MockDatabaseSuite.scala
@@ -1,0 +1,38 @@
+package com.databricks.spark.redshift
+
+import java.sql.{PreparedStatement, Connection}
+
+import com.databricks.spark.redshift.TestUtils._
+import org.apache.spark.sql.jdbc.JDBCWrapper
+
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.FunSuite
+
+import scala.util.matching.Regex
+
+class MockDatabaseSuite extends FunSuite with MockFactory {
+  /**
+   * Set up a mocked JDBCWrapper instance that expects a sequence of queries matching the given
+   * regular expressions will be executed, and that the connection returned will be closed.
+   */
+  def mockJdbcWrapper(expectedUrl: String, expectedQueries: Seq[Regex]): JDBCWrapper = {
+    val jdbcWrapper = mock[JDBCWrapper]
+    val mockedConnection = mock[Connection]
+
+    (jdbcWrapper.getConnector _).expects(*, expectedUrl, *).returning(() => mockedConnection)
+
+    inSequence {
+      expectedQueries foreach { r =>
+        val mockedStatement = mock[PreparedStatement]
+        (mockedConnection.prepareStatement(_: String))
+          .expects(where {(sql: String) => r.findFirstMatchIn(sql).nonEmpty})
+          .returning(mockedStatement)
+        (mockedStatement.execute _).expects().returning(true)
+      }
+
+      (mockedConnection.close _).expects()
+    }
+
+    jdbcWrapper
+  }
+}

--- a/src/test/scala/com/databricks/spark/redshift/ParametersSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/ParametersSuite.scala
@@ -67,4 +67,29 @@ class ParametersSuite extends FunSuite with Matchers {
     checkMerge(Map("tempdir" -> "s3://foo/bar", "url" -> "jdbc:postgresql://foo/bar"))
     checkMerge(Map("dbtable" -> "test_table", "tempdir" -> "s3://foo/bar"))
   }
+
+  test("Parameters for Redshift text/string column conversions") {
+    val params =
+      Map(
+        "tempdir" -> "s3://foo/bar",
+        "dbtable" -> "test_table",
+        "url" -> "jdbc:postgresql://foo/bar")
+
+    Parameters.mergeParameters(params)
+
+    val auto = params ++ Map("stringlengths" -> "auto")  // Default
+    Parameters.mergeParameters(auto).stringLengths should equal("AUTO")
+
+    val truncate = params ++ Map("stringlengths" -> "truncate")
+    Parameters.mergeParameters(truncate).stringLengths should equal("TRUNCATE")
+
+    val optimistic = params ++ Map("stringlengths" -> "maxlength")
+    Parameters.mergeParameters(optimistic).stringLengths should equal("MAXLENGTH")
+
+    val none = params ++ Map("stringlengths" -> "default")
+    Parameters.mergeParameters(none).stringLengths should equal("DEFAULT")
+
+    val manual = params ++ Map("stringlengths" -> "manual")
+    Parameters.mergeParameters(manual).stringLengths should equal("MANUAL")
+  }
 }

--- a/src/test/scala/com/databricks/spark/redshift/RedshiftInputFormatSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/RedshiftInputFormatSuite.scala
@@ -123,7 +123,8 @@ class RedshiftInputFormatSuite extends FunSuite with BeforeAndAfterAll {
     withTempDir { dir =>
       val testRecords = Set(
         Seq("a\n", "TX", 1, 1.0, 1000L, 200000000000L),
-        Seq("b", "CA", 2, 2.0, 2000L, 1231412314L))
+        Seq("b", "CA", 2, 2.0, 2000L, 1231412314L)
+      )
       val escaped = escape(testRecords.map(_.map(_.toString)), DEFAULT_DELIMITER)
       writeToFile(escaped, new File(dir, "part-00000"))
 
@@ -135,6 +136,7 @@ class RedshiftInputFormatSuite extends FunSuite with BeforeAndAfterAll {
       val srdd = sqlContext.redshiftFile(
         dir.toString,
         "name varchar(10) state text id integer score float big_score numeric(4, 0) some_long bigint")
+
       val expectedSchema = StructType(Seq(
         StructField("name", StringType, nullable = true),
         StructField("state", StringType, nullable = true),
@@ -142,13 +144,14 @@ class RedshiftInputFormatSuite extends FunSuite with BeforeAndAfterAll {
         StructField("score", DoubleType, nullable = true),
         StructField("big_score", LongType, nullable = true),
         StructField("some_long", LongType, nullable = true)))
-      assert(srdd.schema === expectedSchema)
+
       val parsed = srdd.map {
         case Row(name: String, state: String, id: Int, score: Double,
                  bigScore: Long, someLong: Long) =>
           Seq(name, state, id, score, bigScore, someLong)
       }.collect().toSet
 
+      assert(srdd.schema === expectedSchema)
       assert(parsed === testRecords)
     }
   }

--- a/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
@@ -172,7 +172,7 @@ class RedshiftSourceSuite
   }
 
   test("DefaultSource supports simple column filtering") {
-
+    //TODO: DRY ME
     val params = Map("url" -> "jdbc:postgresql://foo/bar",
       "tempdir" -> "tmp",
       "dbtable" -> "test_table",
@@ -201,6 +201,7 @@ class RedshiftSourceSuite
 
   test("DefaultSource supports user schema, pruned and filtered scans") {
 
+    //TODO: DRY ME
     val params = Map("url" -> "jdbc:postgresql://foo/bar",
       "tempdir" -> "tmp",
       "dbtable" -> "test_table",
@@ -478,9 +479,17 @@ class RedshiftSourceSuite
     }
   }
 
+  test("Basic string field extraction") {
+    val rdd = sc.parallelize(expectedData)
+    val testSqlContext = new SQLContext(sc)
+    val df = testSqlContext.createDataFrame(rdd, TestUtils.testSchema)
+
+    val dfMetaSchema = Conversions.injectMetaSchema(testSqlContext, df)
+
+//    assert(dfMetaSchema.schema("testString").metadata.getDouble("maxLength") == 1.0)
+  }
+
   test("DefaultSource has default constructor, required by Data Source API") {
     new DefaultSource()
   }
-
-
 }

--- a/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
@@ -412,7 +412,7 @@ class RedshiftSourceSuite
     val testSqlContext = new SQLContext(sc)
     val df = testSqlContext.createDataFrame(rdd, TestUtils.testSchema)
 
-    val dfMetaSchema = StringMetaSchema.computeEnhancedDf(df)
+    val dfMetaSchema = MetaSchema.computeEnhancedDf(df)
 
     assert(dfMetaSchema.schema("testString").metadata.getLong("maxLength") == 10)
   }

--- a/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
@@ -124,7 +124,7 @@ class RedshiftSourceSuite
 
     // Construct the source with a custom schema
     val source = new DefaultSource(jdbcWrapper)
-    val relation = source.createRelation(testSqlContext, TestUtils.params, TestUtils.testSchema)
+    val relation = source.createRelation(testSqlContext, TestUtils.params, testSchema)
 
     val rdd = relation.asInstanceOf[PrunedFilteredScan].buildScan(Array("testByte", "testBool"), Array.empty[Filter])
     val prunedExpectedValues =
@@ -145,7 +145,7 @@ class RedshiftSourceSuite
 
     // Construct the source with a custom schema
     val source = new DefaultSource(jdbcWrapper)
-    val relation = source.createRelation(testSqlContext, TestUtils.params, TestUtils.testSchema)
+    val relation = source.createRelation(testSqlContext, TestUtils.params, testSchema)
 
     // Define a simple filter to only include a subset of rows
     val filters: Array[Filter] =
@@ -180,7 +180,7 @@ class RedshiftSourceSuite
           "distkey" -> "testInt")
 
     val rdd = sc.parallelize(expectedData.toSeq)
-    val df = testSqlContext.createDataFrame(rdd, TestUtils.testSchema)
+    val df = testSqlContext.createDataFrame(rdd, testSchema)
 
     val expectedCommands =
       Seq("DROP TABLE IF EXISTS test_table_staging_.*".r,
@@ -227,7 +227,7 @@ class RedshiftSourceSuite
         "usestagingtable" -> "true")
 
     val rdd = sc.parallelize(expectedData.toSeq)
-    val df = testSqlContext.createDataFrame(rdd, TestUtils.testSchema)
+    val df = testSqlContext.createDataFrame(rdd, testSchema)
 
     val jdbcWrapper = mock[JDBCWrapper]
     val mockedConnection = mock[Connection]
@@ -306,7 +306,7 @@ class RedshiftSourceSuite
     val jdbcUrl = "jdbc:postgresql://foo/bar"
 
     val rdd = sc.parallelize(expectedData.toSeq)
-    val df = testSqlContext.createDataFrame(rdd, TestUtils.testSchema)
+    val df = testSqlContext.createDataFrame(rdd, testSchema)
 
     val expectedCommands =
       Seq("CREATE TABLE IF NOT EXISTS test_table .*".r,
@@ -348,7 +348,7 @@ class RedshiftSourceSuite
           "aws_secret_access_key" -> "test2")
 
     val rdd = sc.parallelize(expectedData.toSeq)
-    val df = testSqlContext.createDataFrame(rdd, TestUtils.testSchema)
+    val df = testSqlContext.createDataFrame(rdd, testSchema)
 
     // Check that SaveMode.ErrorIfExists throws an exception
 
@@ -376,7 +376,7 @@ class RedshiftSourceSuite
         "aws_secret_access_key" -> "test2")
 
     val rdd = sc.parallelize(expectedData.toSeq)
-    val df = testSqlContext.createDataFrame(rdd, TestUtils.testSchema)
+    val df = testSqlContext.createDataFrame(rdd, testSchema)
 
     // Check that SaveMode.Ignore does nothing
 
@@ -396,7 +396,7 @@ class RedshiftSourceSuite
 
     val rdd = sc.parallelize(expectedData)
     val testSqlContext = new SQLContext(sc)
-    val df = testSqlContext.createDataFrame(rdd, TestUtils.testSchema)
+    val df = testSqlContext.createDataFrame(rdd, testSchema)
 
     intercept[Exception] {
       df.saveAsRedshiftTable(invalid)
@@ -410,7 +410,7 @@ class RedshiftSourceSuite
   test("Basic string field extraction") {
     val rdd = sc.parallelize(expectedData)
     val testSqlContext = new SQLContext(sc)
-    val df = testSqlContext.createDataFrame(rdd, TestUtils.testSchema)
+    val df = testSqlContext.createDataFrame(rdd, testSchema)
 
     val dfMetaSchema = MetaSchema.computeEnhancedDf(df)
 

--- a/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
@@ -486,7 +486,7 @@ class RedshiftSourceSuite
 
     val dfMetaSchema = Conversions.injectMetaSchema(testSqlContext, df)
 
-//    assert(dfMetaSchema.schema("testString").metadata.getDouble("maxLength") == 1.0)
+    assert(dfMetaSchema.schema("testString").metadata.getLong("maxLength") == 10)
   }
 
   test("DefaultSource has default constructor, required by Data Source API") {

--- a/src/test/scala/com/databricks/spark/redshift/SchemaGenerationSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/SchemaGenerationSuite.scala
@@ -1,0 +1,89 @@
+package com.databricks.spark.redshift
+
+import java.io.File
+
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.{DataFrame, SQLContext, Row}
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.{BeforeAndAfterAll, Matchers, FunSuite}
+
+class SchemaGenerationSuite extends FunSuite with Matchers with MockFactory with BeforeAndAfterAll {
+  /**
+   * Expected parsed output corresponding to the output of testData.
+   */
+  val expectedData =
+    Array(
+      Row(1.toByte, true, TestUtils.toTimestamp(2015, 6, 1, 0, 0, 0), 1234152.123124981,
+        1.0f, 42, 1239012341823719L, 23, "Unicode是樂趣", TestUtils.toTimestamp(2015, 6, 1, 0, 0, 0, 1)),
+      Row(1.toByte, false, TestUtils.toTimestamp(2015, 6, 2, 0, 0, 0), 0.0, 0.0f, 42, 1239012341823719L, -13, "asdf",
+        TestUtils.toTimestamp(2015, 6, 2, 0, 0, 0, 0)),
+      Row(0.toByte, null, TestUtils.toTimestamp(2015, 6, 3, 0, 0, 0), 0.0, -1.0f, 4141214, 1239012341823719L, null, "f",
+        TestUtils.toTimestamp(2015, 6, 3, 0, 0, 0)),
+      Row(0.toByte, false, null, -1234152.123124981, 100000.0f, null, 1239012341823719L, 24, "___|_123", null),
+      Row(List.fill(10)(null): _*))
+
+  var sc: SparkContext = _
+  var testSqlContext: SQLContext = _
+  var df: DataFrame = _
+
+  def varcharCol(meta:Metadata): String = {
+    val maxLength:Long = meta.getLong("maxLength")
+
+    maxLength match {
+      case _:Long => s"VARCHAR($maxLength)"
+      case _ => "VARCHAR(255)"
+    }
+  }
+
+  /**
+   * Compute the schema string for this RDD.
+   */
+  def schemaString(df: DataFrame): String = {
+    val sb = new StringBuilder()
+
+    df.schema.fields foreach { field => {
+      val name = field.name
+      val typ: String =
+        field match {
+          case StructField(_, IntegerType, _, _) => "INTEGER"
+          case StructField(_, LongType, _, _) => "BIGINT"
+          case StructField(_, DoubleType, _, _) => "DOUBLE PRECISION"
+          case StructField(_, FloatType, _, _) => "REAL"
+          case StructField(_, ShortType, _, _) => "INTEGER"
+          case StructField(_, ByteType, _, _) => "BYTE"
+          case StructField(_, BooleanType, _, _) => "BOOLEAN"
+          case StructField(_, StringType, _, metadata) => varcharCol(metadata)
+          case StructField(_, BinaryType, _, _) => "BLOB"
+          case StructField(_, TimestampType, _, _) => "TIMESTAMP"
+          case StructField(_, DateType, _, _) => "DATE"
+          case StructField(_, t:DecimalType, _, _) => s"DECIMAL(${t.precision}},${t.scale}})"
+          case _ => throw new IllegalArgumentException(s"Don't know how to save $field to JDBC")
+        }
+      val nullable = if (field.nullable) "" else "NOT NULL"
+      sb.append(s", $name $typ $nullable")
+    }
+    }
+    if (sb.length < 2) "" else sb.substring(2)
+  }
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    sc = new TestContext
+    testSqlContext = new SQLContext(sc)
+
+    df = testSqlContext.createDataFrame(sc.parallelize(expectedData), TestUtils.testSchema)
+  }
+
+  override def afterAll(): Unit = {
+    sc.stop()
+    super.afterAll()
+  }
+
+  test("Schema inference") {
+    val enhancedDf:DataFrame = Conversions.injectMetaSchema(testSqlContext, df)
+
+    schemaString(enhancedDf) should equal("testByte BYTE , testBool BOOLEAN , testDate DATE , testDouble DOUBLE PRECISION , testFloat REAL , testInt INTEGER , testLong BIGINT , testShort INTEGER , testString VARCHAR(10) , testTimestamp TIMESTAMP ")
+  }
+}

--- a/src/test/scala/com/databricks/spark/redshift/SchemaGenerationSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/SchemaGenerationSuite.scala
@@ -1,25 +1,40 @@
 package com.databricks.spark.redshift
 
 import java.io.File
+import java.sql.Connection
+
+import com.databricks.spark.redshift.TestUtils._
 
 import org.apache.spark.SparkContext
-import org.apache.spark.sql.types._
-import org.apache.spark.sql.{DataFrame, SQLContext, Row}
-import org.scalamock.scalatest.MockFactory
-import org.scalatest.{BeforeAndAfterAll, Matchers, FunSuite}
+import org.apache.spark.sql.jdbc.JDBCWrapper
+import org.apache.spark.sql.{SaveMode, DataFrame, SQLContext, Row}
+import org.scalatest.{BeforeAndAfterAll, Matchers}
+import scala.util.matching.Regex
 
-class SchemaGenerationSuite extends FunSuite with Matchers with MockFactory with BeforeAndAfterAll {
+class SchemaGenerationSuite extends MockDatabaseSuite with Matchers with BeforeAndAfterAll {
+  // TODO: DRY ME
+
+  /**
+   * Temporary folder for unloading data to
+   */
+  val tempDir = {
+    var dir = File.createTempFile("spark_redshift_tests", "")
+    dir.delete()
+    dir.mkdirs()
+    dir.toURI.toString
+  }
+
   /**
    * Expected parsed output corresponding to the output of testData.
    */
   val expectedData =
     Array(
-      Row(1.toByte, true, TestUtils.toTimestamp(2015, 6, 1, 0, 0, 0), 1234152.123124981,
-        1.0f, 42, 1239012341823719L, 23, "Unicode是樂趣", TestUtils.toTimestamp(2015, 6, 1, 0, 0, 0, 1)),
-      Row(1.toByte, false, TestUtils.toTimestamp(2015, 6, 2, 0, 0, 0), 0.0, 0.0f, 42, 1239012341823719L, -13, "asdf",
-        TestUtils.toTimestamp(2015, 6, 2, 0, 0, 0, 0)),
-      Row(0.toByte, null, TestUtils.toTimestamp(2015, 6, 3, 0, 0, 0), 0.0, -1.0f, 4141214, 1239012341823719L, null, "f",
-        TestUtils.toTimestamp(2015, 6, 3, 0, 0, 0)),
+      Row(1.toByte, true, toTimestamp(2015, 6, 1, 0, 0, 0), 1234152.123124981,
+        1.0f, 42, 1239012341823719L, 23, "Unicode是樂趣", toTimestamp(2015, 6, 1, 0, 0, 0, 1)),
+      Row(1.toByte, false, toTimestamp(2015, 6, 2, 0, 0, 0), 0.0, 0.0f, 42, 1239012341823719L, -13, "asdf",
+        toTimestamp(2015, 6, 2, 0, 0, 0, 0)),
+      Row(0.toByte, null, toTimestamp(2015, 6, 3, 0, 0, 0), 0.0, -1.0f, 4141214, 1239012341823719L, null, "f",
+        toTimestamp(2015, 6, 3, 0, 0, 0)),
       Row(0.toByte, false, null, -1234152.123124981, 100000.0f, null, 1239012341823719L, 24, "___|_123", null),
       Row(List.fill(10)(null): _*))
 
@@ -33,17 +48,32 @@ class SchemaGenerationSuite extends FunSuite with Matchers with MockFactory with
     sc = new TestContext
     testSqlContext = new SQLContext(sc)
 
-    df = testSqlContext.createDataFrame(sc.parallelize(expectedData), TestUtils.testSchema)
+    df = testSqlContext.createDataFrame(sc.parallelize(expectedData), testSchema)
   }
 
   override def afterAll(): Unit = {
+    val temp = new File(tempDir)
+    val tempFiles = temp.listFiles()
+    if(tempFiles != null) tempFiles foreach {
+      case f => if(f != null) f.delete()
+    }
+    temp.delete()
+
     sc.stop()
     super.afterAll()
   }
 
-  test("Schema inference") {
-    val enhancedDf: DataFrame = StringMetaSchema.computeEnhancedDf(df)
+  test("generating the table creation SQL") {
+    val expectedCommands = Seq("CREATE TABLE IF NOT EXISTS test_table .*".r)
 
-//        schemaString(enhancedDf) should equal("testByte BYTE , testBool BOOLEAN , testDate DATE , testDouble DOUBLE PRECISION , testFloat REAL , testInt INTEGER , testLong BIGINT , testShort INTEGER , testString VARCHAR(10) , testTimestamp TIMESTAMP ")
+    val mockWrapper = mock[JDBCWrapper]
+    val mockedConnection = mock[Connection]
+      //    val mockWrapper = mockJdbcWrapper("url", Seq.empty[Regex])
+
+    val rsOutput:RedshiftWriter = new RedshiftWriter(mockWrapper)
+
+    val params = Parameters.mergeParameters(TestUtils.params)
+
+    rsOutput.createTableSql(df, params) should equal("CREATE TABLE IF NOT EXISTS test_table (testByte BYTE , testBool BOOLEAN , testDate DATE , testDouble DOUBLE PRECISION , testFloat REAL , testInt INTEGER , testLong BIGINT , testShort INTEGER , testString VARCHAR(10) , testTimestamp TIMESTAMP ) DISTSTYLE EVEN")
   }
 }

--- a/src/test/scala/com/databricks/spark/redshift/TestUtils.scala
+++ b/src/test/scala/com/databricks/spark/redshift/TestUtils.scala
@@ -19,6 +19,7 @@ package com.databricks.spark.redshift
 import java.sql.Timestamp
 import java.util.Calendar
 
+import com.databricks.spark.redshift.Parameters.MergedParameters
 import org.apache.spark.sql.types._
 
 /**
@@ -32,6 +33,14 @@ object TestUtils {
   def makeField(name: String, typ: DataType) = {
     val md = (new MetadataBuilder).putString("name", name).build()
     StructField(name, typ, nullable = true, metadata = md)
+  }
+
+  def params: Map[String, String] = {
+    Map("url" -> "jdbc:postgresql://foo/bar",
+      "tempdir" -> "tmp",
+      "dbtable" -> "test_table",
+      "aws_access_key_id" -> "test1",
+      "aws_secret_access_key" -> "test2")
   }
 
   /**

--- a/src/test/scala/com/databricks/spark/redshift/TestUtils.scala
+++ b/src/test/scala/com/databricks/spark/redshift/TestUtils.scala
@@ -26,15 +26,6 @@ import org.apache.spark.sql.types._
  * Helpers for Redshift tests that require common mocking
  */
 object TestUtils {
-
-  /**
-   * Makes a field for the test schema
-   */
-  def makeField(name: String, typ: DataType) = {
-    val md = (new MetadataBuilder).putString("name", name).build()
-    StructField(name, typ, nullable = true, metadata = md)
-  }
-
   def params: Map[String, String] = {
     Map("url" -> "jdbc:postgresql://foo/bar",
       "tempdir" -> "tmp",
@@ -42,23 +33,6 @@ object TestUtils {
       "aws_access_key_id" -> "test1",
       "aws_secret_access_key" -> "test2")
   }
-
-  /**
-   * Simple schema that includes all data types we support
-   */
-  lazy val testSchema =
-    StructType(
-      Seq(
-        makeField("testByte", ByteType),
-        makeField("testBool", BooleanType),
-        makeField("testDate", DateType),
-        makeField("testDouble", DoubleType),
-        makeField("testFloat", FloatType),
-        makeField("testInt", IntegerType),
-        makeField("testLong", LongType),
-        makeField("testShort", ShortType),
-        makeField("testString", StringType),
-        makeField("testTimestamp", TimestampType)))
 
   /**
    * Convert date components to a millisecond timestamp


### PR DESCRIPTION
Initial work towards supporting long text fields when loading data into Redshift to address the issue reported at https://github.com/databricks/spark-redshift/issues/29. 

Adds an additional step during the table load phase to dynamically calculate the maximum string lengths within each column of the dataframe. Also replaces the default schema generation by Spark SQL in order to support more flexibility and control in how the Redshift schema is generated.

This is an initial, functional approach but hasn't yet been profiled or benchmarked for performance.