### PR TITLE
Add support for temporary IAM credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,12 @@ need to be configured to allow access from your driver application.
     <td>AWS secret access key corresponding to provided access key.</td>
  </tr>
  <tr>
+    <td><tt>aws_security_token</tt></td>
+    <td>No, unless using temporary IAM credentials</td>
+    <td>None</td>
+    <td>AWS security token corresponding to provided access key.</td>
+ </tr>
+ <tr>
     <td><tt>tempdir</tt></td>
     <td>Yes</td>
     <td>No default</td>

--- a/src/main/scala/com/databricks/spark/redshift/Parameters.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Parameters.scala
@@ -201,7 +201,14 @@ private[redshift] object Parameters extends Logging {
         }
       }
 
-      s"aws_access_key_id=$accessKeyId;aws_secret_access_key=$secretAccessKey"
+      val credentials = s"aws_access_key_id=$accessKeyId;aws_secret_access_key=$secretAccessKey"
+
+      if (parameters.contains("aws_security_token")) {
+        val securityToken = parameters("aws_security_token")
+        credentials + s";token=$securityToken"
+      } else {
+        credentials
+      }
     }
   }
 }


### PR DESCRIPTION
Adding support for temporary IAM credentials. Attaching the Security Token (provided by AWS) to the credentials in either COPY or UNLOAD will allow these temporary credentials to work.

More information about [temporary credentials](http://docs.aws.amazon.com/redshift/latest/dg/r_copy-temporary-security-credentials.html).

R=@traviscrawford
