### PR TITLE
Fix roundtrip save/load when column names contain uppercase characters

### DIFF
--- a/src/it/scala/com/databricks/spark/redshift/RedshiftIntegrationSuite.scala
+++ b/src/it/scala/com/databricks/spark/redshift/RedshiftIntegrationSuite.scala
@@ -28,6 +28,7 @@ import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.{AnalysisException, Row, SQLContext, SaveMode}
 import org.apache.spark.sql.hive.test.TestHiveContext
+import org.apache.spark.sql.types._
 
 /**
  * End-to-end tests which run against a real Redshift cluster.
@@ -283,6 +284,35 @@ class RedshiftIntegrationSuite
         .option("tempdir", tempDir)
         .load()
       checkAnswer(loadedDf, TestUtils.expectedData)
+    } finally {
+      conn.prepareStatement(s"drop table if exists $tableName").executeUpdate()
+      conn.commit()
+    }
+  }
+
+  test("roundtrip save and load with uppercase column names") {
+    val tableName = s"roundtrip_write_and_read_with_uppercase_column_names_$randomSuffix"
+    val df = sqlContext.createDataFrame(sc.parallelize(Seq(Row(1))),
+      StructType(StructField("A", IntegerType) :: Nil))
+    try {
+      df.write
+        .format("com.databricks.spark.redshift")
+        .option("url", jdbcUrl)
+        .option("dbtable", tableName)
+        .option("tempdir", tempDir)
+        .mode(SaveMode.ErrorIfExists)
+        .save()
+
+      assert(DefaultJDBCWrapper.tableExists(conn, tableName))
+      val loadedDf = sqlContext.read
+        .format("com.databricks.spark.redshift")
+        .option("url", jdbcUrl)
+        .option("dbtable", tableName)
+        .option("tempdir", tempDir)
+        .load()
+      assert(loadedDf.schema.length === 1)
+      assert(loadedDf.columns === Seq("a"))
+      checkAnswer(loadedDf, Seq(Row(1)))
     } finally {
       conn.prepareStatement(s"drop table if exists $tableName").executeUpdate()
       conn.commit()

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
@@ -166,7 +166,7 @@ class RedshiftWriter(jdbcWrapper: JDBCWrapper) extends Logging {
     if (schemaWithLowercaseColumnNames.map(_.name).toSet.size != data.schema.size) {
       throw new IllegalArgumentException(
         "Cannot save table to Redshift because two or more column names would be identical" +
-        " after conversion to lowercase: " + data.schema.map(_.name))
+        " after conversion to lowercase: " + data.schema.map(_.name).mkString(", "))
     }
 
     // Update the schema so that Avro writes date and timestamp columns as formatted timestamp

--- a/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
@@ -30,7 +30,8 @@ import org.scalatest.{BeforeAndAfterEach, BeforeAndAfterAll, Matchers}
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.sources._
-import org.apache.spark.sql.{DataFrame, Row, SQLContext, SaveMode}
+import org.apache.spark.sql._
+import org.apache.spark.sql.types.{StructType, StructField, IntegerType}
 
 private class TestContext extends SparkContext("local", "RedshiftSourceSuite") {
 
@@ -270,6 +271,23 @@ class RedshiftSourceSuite
     val dirWithAvroFiles = tempDir.listFiles().head.toURI.toString
     val written = testSqlContext.read.format("com.databricks.spark.avro").load(dirWithAvroFiles)
     checkAnswer(written, TestUtils.expectedDataWithConvertedTimesAndDates)
+  }
+
+  test("Cannot write table with column names that become ambiguous under case insensitivity") {
+    val jdbcWrapper = mock[JDBCWrapper]
+    val mockedConnection = mock[Connection]
+    (jdbcWrapper.getConnector _)
+      .expects(*, defaultParams("url"), *)
+      .returning(() => mockedConnection)
+    (mockedConnection.close _).expects()
+
+    val schema = StructType(Seq(StructField("a", IntegerType), StructField("A", IntegerType)))
+    val df = testSqlContext.createDataFrame(sc.emptyRDD[Row], schema)
+    val writer = new RedshiftWriter(jdbcWrapper)
+
+    intercept[IllegalArgumentException] {
+      writer.saveToRedshift(testSqlContext, df, Parameters.mergeParameters(defaultParams))
+    }
   }
 
   test("Failed copies are handled gracefully when using a staging table") {


### PR DESCRIPTION
Our current write implementation faces multiple issues related to differences in how Redshift and Avro handle case-sensitive column names.

#### Issue 1: columns with uppercase characters in their names cannot be loaded into Redshift tables

In Redshift, [field names are case-insensitive and are folded to lower case](http://docs.aws.amazon.com/redshift/latest/dg/r_names.html).

In Avro, on the other hand, [field names are case-sensitive](http://avro.apache.org/docs/1.7.5/spec.html#Names).

This causes problems when trying to do a roundtrip save and load of a table whose schema contains columns whose names contain uppercase characters. It seems that these columns are silently skipped during Redshift loading, leading to unexpected `null` values for those columns (see the regression test added in this patch for an example). Redshift's docs on [COPYing data from Avro format](http://docs.aws.amazon.com/redshift/latest/dg/copy-parameters-data-format.html#copy-avro) explain why this happens: (emphasis mine):

> COPY automatically maps the data elements in the Avro source data to the columns in the target table by matching field names in the Avro schema to column names in the target table. **Column names are always lowercase, so matching field names must also be lowercase.** With the default 'auto' argument, COPY recognizes only the first level of fields, or outer fields, in the structure.
>
> By default, COPY attempts to match all columns in the target table to Avro field names. You can optionally specify a column list.
>
> [...]
>
> If a column is included in the column list and COPY does not find a matching field in the Avro data, then **COPY attempts to load NULL to the column.**

In order to fix this issue, I propose that `spark-redshift` automatically converts column names to lowercase before saving data to Avro.

#### Issue 2: schemas with columns whose names vary only by capitalization/case should not be used to create Redshift tables

The analyzer should fail fast with an informative error message if a user attempts to write a Redshift table using a schema containing columns with names that vary only by capitalization (e.g. `fooBar` and `foobar`).