### PR TITLE
Allow the results of Redshift queries to be loaded into DataFrames

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ val df: DataFrame = sqlContext.read
     .option("tempdir" -> "s3://path/for/temp/data")
     .load()
 
+// Can also load data from a Redshift query
+val df: DataFrame = sqlContext.read
+    .format("com.databricks.spark.redshift")
+    .option("url", "jdbc:redshift://redshifthost:5439/database?user=username&password=pass")
+    .option("query" -> "select x, count(*) my_table group by x")
+    .option("tempdir" -> "s3://path/for/temp/data")
+    .load()
+
 // Apply some transformations to the data as per normal, then you can use the
 // Data Source API to write the data back to another table
 
@@ -80,6 +88,14 @@ df = sql_context.read \
     .format("com.databricks.spark.redshift") \
     .option("url", "jdbc:redshift://redshifthost:5439/database?user=username&password=pass") \
     .option("dbtable" -> "my_table") \
+    .option("tempdir" -> "s3://path/for/temp/data") \
+    .load()
+
+# Read data from a query
+df = sql_context.read \
+    .format("com.databricks.spark.redshift") \
+    .option("url", "jdbc:redshift://redshifthost:5439/database?user=username&password=pass") \
+    .option("query" -> "select x, count(*) my_table group by x") \
     .option("tempdir" -> "s3://path/for/temp/data") \
     .load()
 
@@ -158,10 +174,16 @@ The parameter map or <tt>OPTIONS</tt> provided in Spark SQL supports the followi
 
  <tr>
     <td><tt>dbtable</tt></td>
-    <td>Yes</td>
+    <td>Yes, unless <tt>query</tt> is specified</td>
     <td>No default</td>
-    <td>The table to create or read from in Redshift</td>
- </tr
+    <td>The table to create or read from in Redshift. This parameter is required when saving data back to Redshift.</td>
+ </tr>
+ <tr>
+    <td><tt>query</tt></td>
+    <td>Yes, unless <tt>dbtable</tt> is specified</td>
+    <td>No default</td>
+    <td>The query to read from in Redshift</td>
+ </tr>
  <tr>
     <td><tt>url</tt></td>
     <td>Yes</td>
@@ -195,7 +217,7 @@ need to be configured to allow access from your driver application.
  <tr>
     <td><tt>aws_security_token</tt></td>
     <td>No, unless using temporary IAM credentials</td>
-    <td>None</td>
+    <td>No default</td>
     <td>AWS security token corresponding to provided access key.</td>
  </tr>
  <tr>

--- a/src/it/scala/com/databricks/spark/redshift/RedshiftIntegrationSuite.scala
+++ b/src/it/scala/com/databricks/spark/redshift/RedshiftIntegrationSuite.scala
@@ -235,6 +235,28 @@ class RedshiftIntegrationSuite
       TestUtils.expectedData)
   }
 
+  test("Can load output when 'dbtable' is a subquery wrapped in parentheses") {
+    // scalastyle:off
+    val query =
+      s"""
+        |(select testbyte, testbool
+        |from $test_table
+        |where testbool = true
+        | and teststring = 'Unicode''s樂趣'
+        | and testdouble = 1234152.12312498
+        | and testfloat = 1.0
+        | and testint = 42)
+      """.stripMargin
+    // scalastyle:on
+    val loadedDf = sqlContext.read
+      .format("com.databricks.spark.redshift")
+      .option("url", jdbcUrl)
+      .option("dbtable", query)
+      .option("tempdir", tempDir)
+      .load()
+    checkAnswer(loadedDf, Seq(Row(1, true)))
+  }
+
   test("DefaultSource supports simple column filtering") {
     checkAnswer(
       sqlContext.sql("select testbyte, testbool from test_table"),

--- a/src/it/scala/com/databricks/spark/redshift/RedshiftIntegrationSuite.scala
+++ b/src/it/scala/com/databricks/spark/redshift/RedshiftIntegrationSuite.scala
@@ -257,6 +257,28 @@ class RedshiftIntegrationSuite
     checkAnswer(loadedDf, Seq(Row(1, true)))
   }
 
+  test("Can load output when 'query' is specified instead of 'dbtable'") {
+    // scalastyle:off
+    val query =
+      s"""
+        |select testbyte, testbool
+        |from $test_table
+        |where testbool = true
+        | and teststring = 'Unicode''s樂趣'
+        | and testdouble = 1234152.12312498
+        | and testfloat = 1.0
+        | and testint = 42
+      """.stripMargin
+    // scalastyle:on
+    val loadedDf = sqlContext.read
+      .format("com.databricks.spark.redshift")
+      .option("url", jdbcUrl)
+      .option("query", query)
+      .option("tempdir", tempDir)
+      .load()
+    checkAnswer(loadedDf, Seq(Row(1, true)))
+  }
+
   test("DefaultSource supports simple column filtering") {
     checkAnswer(
       sqlContext.sql("select testbyte, testbool from test_table"),

--- a/src/it/scala/com/databricks/spark/redshift/RedshiftIntegrationSuite.scala
+++ b/src/it/scala/com/databricks/spark/redshift/RedshiftIntegrationSuite.scala
@@ -279,6 +279,16 @@ class RedshiftIntegrationSuite
     checkAnswer(loadedDf, Seq(Row(1, true)))
   }
 
+  test("Can load output of Redshift aggregation queries") {
+    val loadedDf = sqlContext.read
+      .format("com.databricks.spark.redshift")
+      .option("url", jdbcUrl)
+      .option("query", s"select testbool, count(*) from $test_table group by testbool")
+      .option("tempdir", tempDir)
+      .load()
+    checkAnswer(loadedDf, Seq(Row(true, 1), Row(false, 2), Row(null, 2)))
+  }
+
   test("DefaultSource supports simple column filtering") {
     checkAnswer(
       sqlContext.sql("select testbyte, testbool from test_table"),

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
@@ -82,7 +82,6 @@ private[redshift] case class RedshiftRelation(
     val query = s"SELECT $columnList FROM $tableNameOrSubquery $whereClause"
     val fixedUrl = Utils.fixS3Url(params.tempPath)
 
-    println(s"UNLOAD ('$query') TO '$fixedUrl' WITH CREDENTIALS '$credsString' ESCAPE ALLOWOVERWRITE")
     s"UNLOAD ('$query') TO '$fixedUrl' WITH CREDENTIALS '$credsString' ESCAPE ALLOWOVERWRITE"
   }
 

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
@@ -44,7 +44,8 @@ private[redshift] case class RedshiftRelation(
       case Some(schema) => schema
       case None => {
         jdbcWrapper.registerDriver(params.jdbcDriver)
-        jdbcWrapper.resolveTable(params.jdbcUrl, params.table, new Properties())
+        val tableNameOrSubquery = params.query.map(q => s"($q)").orElse(params.table).get
+        jdbcWrapper.resolveTable(params.jdbcUrl, tableNameOrSubquery, new Properties())
       }
     }
   }
@@ -75,16 +76,13 @@ private[redshift] case class RedshiftRelation(
   private def unloadStmnt(columnList: String, whereClause: String) : String = {
     val credsString = params.credentialsString(sqlContext.sparkContext.hadoopConfiguration)
     val tableNameOrSubquery: String = {
-      def sqlEscape(s: String): String = s.replace("'", "\\'")
-      if (!params.table.isEmpty) {
-        sqlEscape(params.table)
-      } else {
-        sys.error("Must specify either 'table' or 'query' param.")
-      }
+      val unescaped = params.query.map(q => s"($q)").orElse(params.table).get
+      unescaped.replace("'", "\\'")
     }
     val query = s"SELECT $columnList FROM $tableNameOrSubquery $whereClause"
     val fixedUrl = Utils.fixS3Url(params.tempPath)
 
+    println(s"UNLOAD ('$query') TO '$fixedUrl' WITH CREDENTIALS '$credsString' ESCAPE ALLOWOVERWRITE")
     s"UNLOAD ('$query') TO '$fixedUrl' WITH CREDENTIALS '$credsString' ESCAPE ALLOWOVERWRITE"
   }
 

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
@@ -36,7 +36,7 @@ class RedshiftWriter(jdbcWrapper: JDBCWrapper) extends Logging {
   /**
    * Generate CREATE TABLE statement for Redshift
    */
-  def createTableSql(data: DataFrame, params: MergedParameters): String = {
+  private def createTableSql(data: DataFrame, params: MergedParameters): String = {
     val schemaSql = jdbcWrapper.schemaString(data.schema)
     val distStyleDef = params.distStyle match {
       case Some(style) => s"DISTSTYLE $style"
@@ -47,17 +47,18 @@ class RedshiftWriter(jdbcWrapper: JDBCWrapper) extends Logging {
       case None => ""
     }
     val sortKeyDef = params.sortKeySpec.getOrElse("")
+    val table = params.table.get
 
-    s"CREATE TABLE IF NOT EXISTS ${params.table} ($schemaSql) $distStyleDef $distKeyDef $sortKeyDef"
+    s"CREATE TABLE IF NOT EXISTS $table ($schemaSql) $distStyleDef $distKeyDef $sortKeyDef"
   }
 
   /**
    * Generate the COPY SQL command
    */
-  def copySql(sqlContext: SQLContext, params: MergedParameters): String = {
+  private def copySql(sqlContext: SQLContext, params: MergedParameters): String = {
     val creds = params.credentialsString(sqlContext.sparkContext.hadoopConfiguration)
     val fixedUrl = Utils.fixS3Url(params.tempPath)
-    s"COPY ${params.table} FROM '$fixedUrl' CREDENTIALS '$creds' FORMAT AS " +
+    s"COPY ${params.table.get} FROM '$fixedUrl' CREDENTIALS '$creds' FORMAT AS " +
       "AVRO 'auto' DATEFORMAT 'YYYY-MM-DD HH:MI:SS'"
   }
 
@@ -65,27 +66,30 @@ class RedshiftWriter(jdbcWrapper: JDBCWrapper) extends Logging {
    * Sets up a staging table then runs the given action, passing the temporary table name
    * as a parameter.
    */
-  def withStagingTable(conn: Connection, params: MergedParameters, action: (String) => Unit) {
+  private def withStagingTable(
+      conn: Connection,
+      table: String,
+      action: (String) => Unit) {
     val randomSuffix = Math.abs(Random.nextInt()).toString
-    val tempTable = s"${params.table}_staging_$randomSuffix"
-    val backupTable = s"${params.table}_backup_$randomSuffix"
+    val tempTable = s"${table}_staging_$randomSuffix"
+    val backupTable = s"${table}_backup_$randomSuffix"
 
     try {
       log.info("Loading new Redshift data to: " + tempTable)
       log.info("Existing data will be backed up in: " + backupTable)
 
       action(tempTable)
-      if (jdbcWrapper.tableExists(conn, params.table)) {
-        conn.prepareStatement(s"ALTER TABLE ${params.table} RENAME TO $backupTable").execute()
+      if (jdbcWrapper.tableExists(conn, table)) {
+        conn.prepareStatement(s"ALTER TABLE $table RENAME TO $backupTable").execute()
       }
-      conn.prepareStatement(s"ALTER TABLE $tempTable RENAME TO ${params.table}").execute()
+      conn.prepareStatement(s"ALTER TABLE $tempTable RENAME TO $table").execute()
     } catch {
       case e: SQLException =>
         if (jdbcWrapper.tableExists(conn, tempTable)) {
           conn.prepareStatement(s"DROP TABLE $tempTable").execute()
         }
         if (jdbcWrapper.tableExists(conn, backupTable)) {
-          conn.prepareStatement(s"ALTER TABLE $backupTable RENAME TO ${params.table}").execute()
+          conn.prepareStatement(s"ALTER TABLE $backupTable RENAME TO $table").execute()
         }
         throw new Exception("Error loading data to Redshift, changes reverted.", e)
     }
@@ -97,11 +101,11 @@ class RedshiftWriter(jdbcWrapper: JDBCWrapper) extends Logging {
    * Perform the Redshift load, including deletion of existing data in the case of an overwrite,
    * and creating the table if it doesn't already exist.
    */
-  def doRedshiftLoad(conn: Connection, data: DataFrame, params: MergedParameters): Unit = {
+  private def doRedshiftLoad(conn: Connection, data: DataFrame, params: MergedParameters): Unit = {
 
     // Overwrites must drop the table, in case there has been a schema update
     if (params.overwrite) {
-      val deleteExisting = conn.prepareStatement(s"DROP TABLE IF EXISTS ${params.table}")
+      val deleteExisting = conn.prepareStatement(s"DROP TABLE IF EXISTS ${params.table.get}")
       deleteExisting.execute()
     }
 
@@ -118,7 +122,7 @@ class RedshiftWriter(jdbcWrapper: JDBCWrapper) extends Logging {
 
     // Execute postActions
     params.postActions.foreach { action =>
-      val actionSql = if (action.contains("%s")) action.format(params.table) else action
+      val actionSql = if (action.contains("%s")) action.format(params.table.get) else action
       log.info("Executing postAction: " + actionSql)
       conn.prepareStatement(actionSql).execute()
     }
@@ -178,12 +182,17 @@ class RedshiftWriter(jdbcWrapper: JDBCWrapper) extends Logging {
    * Write a DataFrame to a Redshift table, using S3 and Avro serialization
    */
   def saveToRedshift(sqlContext: SQLContext, data: DataFrame, params: MergedParameters) : Unit = {
+    if (params.table.isEmpty) {
+      throw new IllegalArgumentException(
+        "For save operations you must specify a Redshift table name with the 'dbtable' parameter")
+    }
+
     val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl, new Properties()).apply()
 
     try {
       if (params.overwrite && params.useStagingTable) {
-        withStagingTable(conn, params, table => {
-          val updatedParams = MergedParameters(params.parameters.updated("dbtable", table))
+        withStagingTable(conn, params.table.get, stagingTable => {
+          val updatedParams = MergedParameters(params.parameters.updated("dbtable", stagingTable))
           unloadData(sqlContext, data, updatedParams.tempPath)
           doRedshiftLoad(conn, data, updatedParams)
         })

--- a/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
@@ -401,15 +401,29 @@ class RedshiftSourceSuite
     ignoreSource.createRelation(testSqlContext, SaveMode.Ignore, defaultParams, expectedDataDF)
   }
 
+  test("Cannot save when 'query' parameter is specified instead of 'dbtable'") {
+    val invalidParams = Map(
+      "url" -> "jdbc:redshift://foo/bar",
+      "tempdir" -> tempDir.toURI.toString,
+      "query" -> "select * from test_table",
+      "aws_access_key_id" -> "test1",
+      "aws_secret_access_key" -> "test2")
+
+    val e1 = intercept[IllegalArgumentException] {
+      expectedDataDF.saveAsRedshiftTable(invalidParams)
+    }
+    assert(e1.getMessage.contains("dbtable"))
+  }
+
   test("Public Scala API rejects invalid parameter maps") {
     val invalidParams = Map("dbtable" -> "foo") // missing tempdir and url
 
-    val e1 = intercept[Exception] {
+    val e1 = intercept[IllegalArgumentException] {
       expectedDataDF.saveAsRedshiftTable(invalidParams)
     }
     assert(e1.getMessage.contains("tempdir"))
 
-    val e2 = intercept[Exception] {
+    val e2 = intercept[IllegalArgumentException] {
       testSqlContext.redshiftTable(invalidParams)
     }
     assert(e2.getMessage.contains("tempdir"))

--- a/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
@@ -31,7 +31,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql._
-import org.apache.spark.sql.types.{ByteType, StructType, StructField, IntegerType}
+import org.apache.spark.sql.types._
 
 private class TestContext extends SparkContext("local", "RedshiftSourceSuite") {
 

--- a/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
@@ -31,7 +31,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql._
-import org.apache.spark.sql.types.{StructType, StructField, IntegerType}
+import org.apache.spark.sql.types.{ByteType, StructType, StructField, IntegerType}
 
 private class TestContext extends SparkContext("local", "RedshiftSourceSuite") {
 


### PR DESCRIPTION
This patch adds support for creating DataFrames from the results of Redshift queries:

- The `dbname` parameter can now accept a query that is wrapped in parentheses, e.g. `(select count(*) from foo`).
- The new `query` parameter is syntactic sugar which lets users omit those parentheses.
- These options are mutually-exclusive and cannot be specified at the same time.
- Only `dbname` can be used for saving data back to Redshift.

This fixes #24.