### PR TITLE
Use maxlength metadata to configure VARCHAR column lengths

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,24 @@ table, the changes will be reverted and the backup table restored if post action
  </tr>
 </table>
 
+## Additional configuration options
+
+### Configuring the maximum size of string columns
+
+When creating Redshift tables, `spark-redshift`'s default behavior is to create `TEXT` columns for string columns. Redshift stores `TEXT` columns as `VARCHAR(256)`, so these columns have a maximum size of 256 characters ([source](http://docs.aws.amazon.com/redshift/latest/dg/r_Character_types.html)).
+
+To support larger columns, you can use the `maxlength` column metadata field to specify the maximum length of individual string columns. This can also be done as a space-savings performance optimization in order to declare columns with a smaller maximum length than the default.
+
+Here is an example of updating a column's metadata field in Scala:
+
+```
+import org.apache.spark.sql.types.MetadataBuilder
+val metadata = new MetadataBuilder().putLong("maxlength", 10).build()
+df.withColumn("colName", col("colName").as("colName", metadata)
+```
+
+Column metadata modification is unsupported in the Python, SQL, and R language APIs.
+
 ## AWS Credentials
 
 Note that you can provide AWS credentials in the parameters above, with Hadoop `fs.*` configuration settings, 

--- a/src/it/scala/com/databricks/spark/redshift/RedshiftIntegrationSuite.scala
+++ b/src/it/scala/com/databricks/spark/redshift/RedshiftIntegrationSuite.scala
@@ -404,6 +404,8 @@ class RedshiftIntegrationSuite
         .option("url", jdbcUrl)
         .option("dbtable", tableName)
         .option("tempdir", tempDir)
+        .option("aws_access_key_id", AWS_ACCESS_KEY_ID)
+        .option("aws_secret_access_key", AWS_SECRET_ACCESS_KEY)
         .mode(SaveMode.ErrorIfExists)
         .save()
       assert(DefaultJDBCWrapper.tableExists(conn, tableName))
@@ -412,6 +414,8 @@ class RedshiftIntegrationSuite
         .option("url", jdbcUrl)
         .option("dbtable", tableName)
         .option("tempdir", tempDir)
+        .option("aws_access_key_id", AWS_ACCESS_KEY_ID)
+        .option("aws_secret_access_key", AWS_SECRET_ACCESS_KEY)
         .load()
       checkAnswer(loadedDf, Seq(Row("a" * 512)))
       // This append should fail due to the string being longer than the maxlength
@@ -421,6 +425,8 @@ class RedshiftIntegrationSuite
           .option("url", jdbcUrl)
           .option("dbtable", tableName)
           .option("tempdir", tempDir)
+          .option("aws_access_key_id", AWS_ACCESS_KEY_ID)
+          .option("aws_secret_access_key", AWS_SECRET_ACCESS_KEY)
           .mode(SaveMode.Append)
           .save()
       }

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftJDBCWrapper.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftJDBCWrapper.scala
@@ -154,7 +154,7 @@ private[redshift] class JDBCWrapper extends Logging {
         case _ => throw new IllegalArgumentException(s"Don't know how to save $field to JDBC")
       }
       val nullable = if (field.nullable) "" else "NOT NULL"
-      sb.append(s", $name $typ $nullable")
+      sb.append(s", $name $typ $nullable".trim)
     }}
     if (sb.length < 2) "" else sb.substring(2)
   }

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftJDBCWrapper.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftJDBCWrapper.scala
@@ -141,7 +141,13 @@ private[redshift] class JDBCWrapper extends Logging {
         case ShortType => "INTEGER"
         case ByteType => "SMALLINT" // Redshift does not support the BYTE type.
         case BooleanType => "BOOLEAN"
-        case StringType => "TEXT"
+        case StringType =>
+          val maxlength = if (field.metadata.contains("maxlength")) {
+            field.metadata.getLong("maxlength")
+          } else {
+            255 // TODO: make this default configurable?
+          }
+          s"VARCHAR($maxlength)"
         case BinaryType => "BLOB"
         case TimestampType => "TIMESTAMP"
         case DateType => "DATE"

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftJDBCWrapper.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftJDBCWrapper.scala
@@ -142,12 +142,11 @@ private[redshift] class JDBCWrapper extends Logging {
         case ByteType => "SMALLINT" // Redshift does not support the BYTE type.
         case BooleanType => "BOOLEAN"
         case StringType =>
-          val maxlength = if (field.metadata.contains("maxlength")) {
-            field.metadata.getLong("maxlength")
+          if (field.metadata.contains("maxlength")) {
+            s"VARCHAR(${field.metadata.getLong("maxlength")})"
           } else {
-            255 // TODO: make this default configurable?
+            "TEXT"
           }
-          s"VARCHAR($maxlength)"
         case BinaryType => "BLOB"
         case TimestampType => "TIMESTAMP"
         case DateType => "DATE"

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
@@ -32,12 +32,13 @@ import org.apache.spark.sql.types._
 /**
  * Functions to write data to Redshift with intermediate Avro serialisation into S3.
  */
-class RedshiftWriter(jdbcWrapper: JDBCWrapper) extends Logging {
+private[redshift] class RedshiftWriter(jdbcWrapper: JDBCWrapper) extends Logging {
 
   /**
    * Generate CREATE TABLE statement for Redshift
    */
-  private def createTableSql(data: DataFrame, params: MergedParameters): String = {
+  // Visible for testing.
+  private[redshift] def createTableSql(data: DataFrame, params: MergedParameters): String = {
     val schemaSql = jdbcWrapper.schemaString(data.schema)
     val distStyleDef = params.distStyle match {
       case Some(style) => s"DISTSTYLE $style"


### PR DESCRIPTION
This patch allows users to specify a `maxlength` column metadata entry for string columns in order to control the width of `VARCHAR` columns in generated Redshift table schemas. This is necessary in order to support string columns that are wider than 256 characters. In addition, this configuration can be used as an optimization to achieve space-savings in Redshift. For more background on the motivation of this feature, see #29.

See also: #53 to improve error reporting when LOAD fails.