### PR TITLE
Allow a single published artifact to work with multiple Hadoop versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,9 @@ cache:
 # Spark 1.5.0 only supports Java 7+.
 matrix:
   include:
-    - jdk: openjdk6
-      scala: 2.10.4
-      env: HADOOP_VERSION="1.0.4" SPARK_VERSION="1.4.1"
-    - jdk: openjdk6
-      scala: 2.10.4
-      env: HADOOP_VERSION="1.2.1" SPARK_VERSION="1.4.1"
+    # We only test Spark 1.4.1 with Hadooop 2.2.0 because
+    # https://github.com/apache/spark/pull/6599 is not present in 1.4.1,
+    # so the published Spark Maven artifacts will not work with Hadoop 1.x.
     - jdk: openjdk6
       scala: 2.10.4
       env: HADOOP_VERSION="2.2.0" SPARK_VERSION="1.4.1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,10 +42,11 @@ env:
     - secure: "LvndQIW6dHs6nyaMHtblGI/oL+s460lOezFs2BoD0Isenb/O/IM+nY5K9HepTXjJIcq8qvUYnojZX1FCrxxOXX2/+/Iihiq7GzJYdmdMC6hLg9bJYeAFk0dWYT88/AwadrJCBOa3ockRLhiO3dkai7Ki5+M1erfaFiAHHMpJxYQ="
 
 script:
-  - sbt -Dhadoop.version=$HADOOP_VERSION -Dspark.version=$SPARK_VERSION coverage test
+  - sbt -Dhadoop.testVersion=$HADOOP_VERSION -Dspark.testVersion=$SPARK_VERSION coverage test
   - if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then sbt -Dhadoop.version=$HADOOP_VERSION -Dspark.version=$SPARK_VERSION coverage it:test 2> /dev/null; fi
   - sbt scalastyle
-  - sbt "test:scalastyle"
+  # Disable scalastyle for tests until https://github.com/scalastyle/scalastyle/issues/156 is fixed:
+  # - sbt "test:scalastyle"
   - sbt "it:scalastyle"
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,13 @@ matrix:
       env: HADOOP_VERSION="2.2.0" SPARK_VERSION="1.4.1"
     - jdk: openjdk7
       scala: 2.10.4
-      env: HADOOP_VERSION="1.0.4" SPARK_VERSION="1.5.0-rc1"
+      env: HADOOP_VERSION="1.0.4" SPARK_VERSION="1.5.0-rc2"
     - jdk: openjdk7
       scala: 2.10.4
-      env: HADOOP_VERSION="1.2.1" SPARK_VERSION="1.5.0-rc1"
+      env: HADOOP_VERSION="1.2.1" SPARK_VERSION="1.5.0-rc2"
     - jdk: openjdk7
       scala: 2.10.4
-      env: HADOOP_VERSION="2.2.0" SPARK_VERSION="1.5.0-rc1"
+      env: HADOOP_VERSION="2.2.0" SPARK_VERSION="1.5.0-rc2"
 env:
   global:
     # AWS_REDSHIFT_JDBC_URL

--- a/project/SparkRedshiftBuild.scala
+++ b/project/SparkRedshiftBuild.scala
@@ -21,7 +21,8 @@ import sbtsparkpackage.SparkPackagePlugin.autoImport._
 import scoverage.ScoverageSbtPlugin
 
 object SparkRedshiftBuild extends Build {
-  val hadoopVersion = settingKey[String]("Hadoop version")
+  val testSparkVersion = settingKey[String]("Spark version to test against")
+  val testHadoopVersion = settingKey[String]("Hadoop version to test against")
 
   // Define a custom test configuration so that unit test helper classes can be re-used under
   // the integration tests configuration; see http://stackoverflow.com/a/20635808.
@@ -37,8 +38,9 @@ object SparkRedshiftBuild extends Build {
       organization := "com.databricks",
       version := "0.4.1-SNAPSHOT",
       scalaVersion := "2.10.4",
-      sparkVersion := sys.props.get("spark.version").getOrElse("1.4.1"),
-      hadoopVersion := sys.props.get("hadoop.version").getOrElse("2.2.0"),
+      sparkVersion := "1.4.1",
+      testSparkVersion := sys.props.get("spark.testVersion").getOrElse(sparkVersion.value),
+      testHadoopVersion := sys.props.get("hadoop.testVersion").getOrElse("1.2.1"),
       spName := "databricks/spark-redshift",
       sparkComponents ++= Seq("sql", "hive"),
       licenses += "Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0"),
@@ -59,6 +61,12 @@ object SparkRedshiftBuild extends Build {
         "com.google.guava" % "guava" % "14.0.1" % "test",
         "org.scalatest" %% "scalatest" % "2.2.1" % "test",
         "org.scalamock" %% "scalamock-scalatest-support" % "3.2" % "test"
+      ),
+      libraryDependencies ++= Seq(
+        "org.apache.hadoop" % "hadoop-client" % testHadoopVersion.value % "test",
+        "org.apache.spark" %% "spark-core" % testSparkVersion.value % "test" exclude("org.apache.hadoop", "hadoop-client"),
+        "org.apache.spark" %% "spark-sql" % testSparkVersion.value % "test" exclude("org.apache.hadoop", "hadoop-client"),
+        "org.apache.spark" %% "spark-hive" % testSparkVersion.value % "test" exclude("org.apache.hadoop", "hadoop-client")
       ),
       ScoverageSbtPlugin.ScoverageKeys.coverageHighlighting := {
         if (scalaBinaryVersion.value == "2.10") false

--- a/project/SparkRedshiftBuild.scala
+++ b/project/SparkRedshiftBuild.scala
@@ -40,7 +40,7 @@ object SparkRedshiftBuild extends Build {
       scalaVersion := "2.10.4",
       sparkVersion := "1.4.1",
       testSparkVersion := sys.props.get("spark.testVersion").getOrElse(sparkVersion.value),
-      testHadoopVersion := sys.props.get("hadoop.testVersion").getOrElse("1.2.1"),
+      testHadoopVersion := sys.props.get("hadoop.testVersion").getOrElse("2.2.0"),
       spName := "databricks/spark-redshift",
       sparkComponents ++= Seq("sql", "hive"),
       licenses += "Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0"),

--- a/project/SparkRedshiftBuild.scala
+++ b/project/SparkRedshiftBuild.scala
@@ -43,6 +43,7 @@ object SparkRedshiftBuild extends Build {
       testHadoopVersion := sys.props.get("hadoop.testVersion").getOrElse("2.2.0"),
       spName := "databricks/spark-redshift",
       sparkComponents ++= Seq("sql", "hive"),
+      spIgnoreProvided := true,
       licenses += "Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0"),
       credentials += Credentials(Path.userHome / ".ivy2" / ".credentials"),
       resolvers +=

--- a/project/SparkRedshiftBuild.scala
+++ b/project/SparkRedshiftBuild.scala
@@ -48,7 +48,7 @@ object SparkRedshiftBuild extends Build {
       resolvers +=
         "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
       resolvers +=
-        "Spark 1.5.0 RC1 Snapshot" at "https://repository.apache.org/content/repositories/orgapachespark-1137",
+        "Spark 1.5.0 RC2 Staging" at "https://repository.apache.org/content/repositories/orgapachespark-1141",
       libraryDependencies ++= Seq(
         "com.amazonaws" % "aws-java-sdk-core" % "1.9.40" % "provided",
         // We require spark-avro, but avro-mapred must be provided to match Hadoop version:

--- a/project/build.properties
+++ b/project/build.properties
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-sbt.version=0.13.6
+sbt.version=0.13.9

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftInputFormat.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftInputFormat.scala
@@ -100,7 +100,12 @@ private[redshift] class RedshiftRecordReader extends RecordReader[JavaLong, Arra
   override def initialize(inputSplit: InputSplit, context: TaskAttemptContext): Unit = {
     val split = inputSplit.asInstanceOf[FileSplit]
     val file = split.getPath
-    val conf = context.getConfiguration
+    val conf: Configuration = {
+      // Use reflection to get the Configuration. This is necessary because TaskAttemptContext is
+      // a class in Hadoop 1.x and an interface in Hadoop 2.x.
+      val method = context.getClass.getMethod("getConfiguration")
+      method.invoke(context).asInstanceOf[Configuration]
+    }
     delimiter = RedshiftInputFormat.getDelimiterOrDefault(conf).asInstanceOf[Byte]
     require(delimiter != escapeChar,
       s"The delimiter and the escape char cannot be the same but found $delimiter.")


### PR DESCRIPTION
This commit allows us to publish one `spark-redshift` artifact which is built against a fixed Hadoop version but which works with both Hadoop 1.x and 2.x. In the past, we published separate artifacts for Hadoop 1.x and 2.x in order to work around a binary incompatibility in `TaskAttemptContext` (see #19). This patch works around the incompatibility using reflection, similar to https://github.com/apache/spark/pull/6599.

In order to make this testable, this patch also modifies our SBT build and Travis configuration so that the test Spark and Hadoop dependencies can be configured separately from the compile dependencies.