### PR TITLE
Log warning if tempdir S3 bucket lacks an object lifecycle configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,28 +19,19 @@ JDBC is used to automatically trigger the appropriate `COPY` and `UNLOAD` comman
 
 ## Installation
 
-`spark-redshift` requires Apache Spark version 1.4+ and Amazon Redshift version 1.0.963+ for
-writing with Avro data.
+`spark-redshift` requires Apache Spark 1.4+ and Amazon Redshift 1.0.963+.
 
 You may use this library in your applications with the following dependency information:
 
 ```
 groupId: com.databricks
 artifactId: spark-redshift
-version: 0.4.1
+version: 0.5.0-SNAPSHOT
 ```
 
-The project makes use of [`spark-avro`](https://github.com/databricks/spark-avro), which is pulled
-in as a dependency, however you'll need to provide the corresponding `avro-mapred` matching the Hadoop
-distribution that you plan to deploy to.
+You will also need to provide a JDBC driver that is compatible with Redshift. Amazon recommend that you use [their driver](http://docs.aws.amazon.com/redshift/latest/mgmt/configure-jdbc-connection.html), which is distributed as a JAR that is hosted on Amazon's website. This library has also been successfully tested using the Postgres JDBC driver.
 
-Further, as Redshift is an AWS product, some AWS libraries will be required. This library expects that
-your deployment environment will include `hadoop-aws`, or other things necessary to access S3, credentials,
-etc. Check the dependencies with "provided" scope in <tt>build.sbt</tt> if you're at all unclear.
-
-You're also going to need a JDBC driver that is compatible with Redshift. Amazon recommend that you
-use [their driver](http://docs.aws.amazon.com/redshift/latest/mgmt/configure-jdbc-connection.html),
-although this library has also been successfully tested using the Postgres JDBC driver.
+**Note on Hadoop versions**: This library depends on [`spark-avro`](https://github.com/databricks/spark-avro), which should automatically be downloaded because it is declared as a dependency. However, you may need to provide the corresponding `avro-mapred` dependency which matches your Hadoop distribution. In most deployments, however, this dependency will be automatically provided by your cluster's Spark assemblies and no additional action will be required.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# `spark-redshift`
+# # `spark-redshift`
 
 [![Build Status](https://travis-ci.org/databricks/spark-redshift.svg?branch=master)](https://travis-ci.org/databricks/spark-redshift)
 [![codecov.io](http://codecov.io/github/databricks/spark-redshift/coverage.svg?branch=master)](http://codecov.io/github/databricks/spark-redshift?branch=master)
@@ -143,7 +143,7 @@ val records = sc.newAPIHadoopFile(
 
 You can provide AWS credentials via the parameters listed below, with Hadoop `fs.*` configuration settings, or by making them available via the usual environment variables, system properties or IAM roles.
 
-**:warning: Note**: `spark-redshift` does not clean up the temporary files that it creates in S3. As a result, we recommend that you use an S3 bucket with an [object lifecycle configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) to ensure that temporary files are automatically deleted after a specified expiration period. By default, `spark-redshift` will refuse to read / write data to S3 buckets that do not have object lifecycle configurations; if you plan to clean up the temporary files manually, then you can use the `disable_s3_lifecycle_check` configuration option to disable this safety check.
+**:warning: Note**: `spark-redshift` does not clean up the temporary files that it creates in S3. As a result, we recommend that you use a dedicated temporary S3 bucket with an [object lifecycle configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) to ensure that temporary files are automatically deleted after a specified expiration period.
 
 ### Parameters
 
@@ -214,12 +214,6 @@ Redshift when writing. If you're using `spark-redshift` as part of a regular ETL
 set a <a href="http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html">Lifecycle Policy</a> on a bucket
 and use that as a temp location for this data.
     </td>
- </tr>
- <tr>
- 	<td><tt>disable_s3_lifecycle_check<tt></td>
- 	<td>No</td>
- 	<td>false</td>
- 	<td>If true, disables an automatic check which ensures that the <tt>tempdir</tt> S3 bucket is configured with an object lifecycle policy.
  </tr>
  <tr>
     <td><tt>jdbcdriver</tt></td>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# # `spark-redshift`
+# `spark-redshift`
 
 [![Build Status](https://travis-ci.org/databricks/spark-redshift.svg?branch=master)](https://travis-ci.org/databricks/spark-redshift)
 [![codecov.io](http://codecov.io/github/databricks/spark-redshift/coverage.svg?branch=master)](http://codecov.io/github/databricks/spark-redshift?branch=master)

--- a/project/SparkRedshiftBuild.scala
+++ b/project/SparkRedshiftBuild.scala
@@ -55,9 +55,10 @@ object SparkRedshiftBuild extends Build {
       resolvers +=
         "Spark 1.5.0 RC2 Staging" at "https://repository.apache.org/content/repositories/orgapachespark-1141",
       libraryDependencies ++= Seq(
-        "com.amazonaws" % "aws-java-sdk-core" % "1.9.40" % "provided",
-        "com.amazonaws" % "aws-java-sdk-s3" % "1.9.40" % "provided",
-        // We require spark-avro, but avro-mapred must be provided to match Hadoop version:
+        "com.amazonaws" % "aws-java-sdk-core" % "1.9.40",
+        "com.amazonaws" % "aws-java-sdk-s3" % "1.9.40",
+        // We require spark-avro, but avro-mapred must be provided to match Hadoop version.
+        // In most cases, avro-mapred will be provided as part of the Spark assembly JAR.
         "com.databricks" %% "spark-avro" % "1.0.0",
         "org.apache.avro" % "avro-mapred" % "1.7.6" % "provided" exclude("org.mortbay.jetty", "servlet-api"),
         // A Redshift-compatible JDBC driver must be present on the classpath for spark-redshift to work.

--- a/project/SparkRedshiftBuild.scala
+++ b/project/SparkRedshiftBuild.scala
@@ -52,6 +52,7 @@ object SparkRedshiftBuild extends Build {
         "Spark 1.5.0 RC2 Staging" at "https://repository.apache.org/content/repositories/orgapachespark-1141",
       libraryDependencies ++= Seq(
         "com.amazonaws" % "aws-java-sdk-core" % "1.9.40" % "provided",
+        "com.amazonaws" % "aws-java-sdk-s3" % "1.9.40" % "provided",
         // We require spark-avro, but avro-mapred must be provided to match Hadoop version:
         "com.databricks" %% "spark-avro" % "1.0.0",
         "org.apache.avro" % "avro-mapred" % "1.7.6" % "provided" exclude("org.mortbay.jetty", "servlet-api"),

--- a/src/main/scala/com/databricks/spark/redshift/Parameters.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Parameters.scala
@@ -267,6 +267,9 @@ private[redshift] object Parameters extends Logging {
         val bucketLifecycleConfiguration = s3Client.getBucketLifecycleConfiguration(bucket)
         val key = s3URI.getKey
         val someRuleMatchesTempDir = bucketLifecycleConfiguration.getRules.asScala.exists { rule =>
+          // Note: this only checks that there is an active rule which matches the temp directory;
+          // it does not actually check that the rule will delete the files. This check is still
+          // better than nothing, though, and we can always improve it later.
           rule.getStatus == BucketLifecycleConfiguration.ENABLED && key.startsWith(rule.getPrefix)
         }
         if (!someRuleMatchesTempDir) {

--- a/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
@@ -81,8 +81,7 @@ class RedshiftSourceSuite
     "tempdir" -> tempDir.toURI.toString,
     "dbtable" -> "test_table",
     "aws_access_key_id" -> "test1",
-    "aws_secret_access_key" -> "test2",
-    "disable_s3_lifecycle_check" -> "true")
+    "aws_secret_access_key" -> "test2")
 
   override def beforeAll(): Unit = {
     super.beforeAll()

--- a/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
@@ -81,7 +81,8 @@ class RedshiftSourceSuite
     "tempdir" -> tempDir.toURI.toString,
     "dbtable" -> "test_table",
     "aws_access_key_id" -> "test1",
-    "aws_secret_access_key" -> "test2")
+    "aws_secret_access_key" -> "test2",
+    "disable_s3_lifecycle_check" -> "true")
 
   override def beforeAll(): Unit = {
     super.beforeAll()


### PR DESCRIPTION
This patch adds automatic checks which warn users if `tempdir` points to a S3 bucket that lacks an object lifecycle configuration. The goal of this check is to make sure that users realize that these files will need to be manually cleaned up.

I also performed a bit of README cleanup and updated the build file to mark the AWS SDK as a required dependency.