### PR TITLE
Deprecate several APIs before 0.5.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,26 +119,11 @@ OPTIONS (dbtable 'my_table',
          url 'jdbc:redshift://host:port/db?user=username&password=pass');
 ```
 
-### Scala helper functions
-
-The <tt>com.databricks.spark.redshift</tt> package has some shortcuts if you're working directly
-from a Scala application and don't want to use the Data Sources API:
-
-```scala
-import com.databricks.spark.redshift._
-
-val sqlContext = new SQLContext(sc)
-
-val dataFrame = sqlContext.redshiftTable( ... )
-dataFrame.saveAsRedshiftTable( ... )
-```
-
 ### Hadoop InputFormat
 
 The library contains a Hadoop input format for Redshift tables unloaded with the ESCAPE option,
 which you may make direct use of as follows:
 
-Usage in Spark Core:
 ```scala
 import com.databricks.spark.redshift.RedshiftInputFormat
 
@@ -147,17 +132,6 @@ val records = sc.newAPIHadoopFile(
   classOf[RedshiftInputFormat],
   classOf[java.lang.Long],
   classOf[Array[String]])
-```
-
-Usage in Spark SQL:
-```scala
-import com.databricks.spark.redshift._
-
-// Call redshiftFile() that returns a SchemaRDD with all string columns.
-val records: DataFrame = sqlContext.redshiftFile(path, Seq("name", "age"))
-
-// Call redshiftFile() with the table schema.
-val records: DataFrame = sqlContext.redshiftFile(path, "name varchar(10) age integer")
 ```
 
 ## Parameters
@@ -235,14 +209,6 @@ and use that as a temp location for this data.
     <td>No</td>
     <td><tt>com.amazon.redshift.jdbc4.Driver</tt></td>
     <td>The class name of the JDBC driver to load before JDBC operations. Must be on classpath.</td>
- </tr>
- <tr>
-    <td><tt>overwrite</tt></td>
-    <td>No</td>
-    <td><tt>false</tt></td>
-    <td>
-If true, drop any existing data before writing new content. Only applies when using the Scala `saveAsRedshiftTable` function
-directly, as `SaveMode` will be preferred when using the Data Source API. See also <tt>usestagingtable</tt></td>
  </tr>
  <tr>
     <td><tt>diststyle</tt></td>

--- a/src/main/scala/com/databricks/spark/redshift/Parameters.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Parameters.scala
@@ -123,6 +123,7 @@ private[redshift] object Parameters extends Logging {
      *
      * Defaults to false.
      */
+    @deprecated("Use SaveMode instead", "0.5.0")
     def overwrite: Boolean = parameters("overwrite").toBoolean
 
     /**

--- a/src/main/scala/com/databricks/spark/redshift/SchemaParser.scala
+++ b/src/main/scala/com/databricks/spark/redshift/SchemaParser.scala
@@ -22,7 +22,11 @@ import org.apache.spark.sql.types._
 
 /**
  * A simple parser for Redshift table schemas.
+ *
+ * Note: the only method which uses this class has been deprecated, so this class should be
+ * removed in `spark-redshift` 0.6. We will not accept patches to extend this parser.
  */
+@deprecated("Do not use SchemaParser directly", "0.5.0")
 private[redshift] object SchemaParser extends JavaTokenParsers {
   // redshift data types: http://docs.aws.amazon.com/redshift/latest/dg/c_Supported_data_types.html
   private val SMALLINT: Parser[DataType] = ("smallint" | "int2") ^^^ ShortType

--- a/src/main/scala/com/databricks/spark/redshift/package.scala
+++ b/src/main/scala/com/databricks/spark/redshift/package.scala
@@ -17,10 +17,9 @@
 
 package com.databricks.spark
 
-import com.databricks.spark.redshift.DefaultJDBCWrapper
-import org.apache.spark.sql.functions._
+import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
-import org.apache.spark.sql.{DataFrame, Row, SQLContext}
+import org.apache.spark.sql.{DataFrame, DataFrameReader, DataFrameWriter, Row, SQLContext}
 
 package object redshift {
 
@@ -47,6 +46,7 @@ package object redshift {
     /**
      * Reads a table unload from Redshift with its schema in format "name0 type0 name1 type1 ...".
      */
+    @deprecated("Use data sources API or perform string -> data type casts yourself", "0.5.0")
     def redshiftFile(path: String, schema: String): DataFrame = {
       val structType = SchemaParser.parseSchema(schema)
       val casts = structType.fields.map { field =>
@@ -59,6 +59,7 @@ package object redshift {
      * Read a Redshift table into a DataFrame, using S3 for data transfer and JDBC
      * to control Redshift and resolve the schema
      */
+    @deprecated("Use sqlContext.read()", "0.5.0")
     def redshiftTable(parameters: Map[String, String]): DataFrame = {
       val params = Parameters.mergeParameters(parameters)
       sqlContext.baseRelationToDataFrame(
@@ -69,11 +70,13 @@ package object redshift {
   /**
    * Add write functionality to DataFrame
    */
+  @deprecated("Use DataFrame.write()", "0.5.0")
   implicit class RedshiftDataFrame(dataFrame: DataFrame) {
 
     /**
      * Load the DataFrame into a Redshift database table
      */
+    @deprecated("Use DataFrame.write()", "0.5.0")
     def saveAsRedshiftTable(parameters: Map[String, String]): Unit = {
       val params = Parameters.mergeParameters(parameters)
       DefaultRedshiftWriter.saveToRedshift(dataFrame.sqlContext, dataFrame, params)


### PR DESCRIPTION
This commit deprecates several APIs in advance of the 0.5.0 release:

- Deprecate the Scala helper functions, since they don't save much typing. Unlike some of the other data sources where the typical configuration consists only of a filename (such as Avro or Parquet), Redshift has several required configuration parameters. These convenience methods are really only saving users from the burden of writing "com.databricks.spark.redshift", which doesn't seem like a huge win.
- Deprecate the variant of `redshiftFile` which accepts a schema string. This code path is not tested and is likely to diverge over time. Most users will be better off using the data sources API or performing the type casts themselves.
- Remove the documentation for the `overwrite` configuration option, which is only used by the deprecated APIs. For consistency / minimizing the testing surface, I think that the code paths for dealing with overwriting should be written with reference to data sources' `SaveMode` API. I'm going to add some additional unit tests for this in a separate followup PR to make sure that the `SaveMode` flags are handled properly.
- Remove the documentation for the other deprecated methods.