### PR TITLE
Remove dependency on Spark's Logging trait

### DIFF
--- a/project/SparkRedshiftBuild.scala
+++ b/project/SparkRedshiftBuild.scala
@@ -55,6 +55,8 @@ object SparkRedshiftBuild extends Build {
       resolvers +=
         "Spark 1.5.0 RC3 Staging" at "https://repository.apache.org/content/repositories/orgapachespark-1143",
       libraryDependencies ++= Seq(
+        // The SLF4J API is provided by Spark:
+        "org.slf4j" % "slf4j-api" % "1.7.5" % "provided",
         // These Amazon SDK depdencies are marked as 'provided' in order to reduce the risk of
         // dependency conflicts with other user libraries. In many environments, such as EMR and
         // Databricks, the Amazon SDK will already be on the classpath. In other cases, the SDK is

--- a/project/SparkRedshiftBuild.scala
+++ b/project/SparkRedshiftBuild.scala
@@ -55,8 +55,7 @@ object SparkRedshiftBuild extends Build {
       resolvers +=
         "Spark 1.5.0 RC3 Staging" at "https://repository.apache.org/content/repositories/orgapachespark-1143",
       libraryDependencies ++= Seq(
-        // The SLF4J API is provided by Spark:
-        "org.slf4j" % "slf4j-api" % "1.7.5" % "provided",
+        "org.slf4j" % "slf4j-api" % "1.7.5",
         // These Amazon SDK depdencies are marked as 'provided' in order to reduce the risk of
         // dependency conflicts with other user libraries. In many environments, such as EMR and
         // Databricks, the Amazon SDK will already be on the classpath. In other cases, the SDK is

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -123,6 +123,11 @@ This file is divided into 3 sections:
       // scalastyle:on println]]></customMessage>
   </check>
 
+  <check customId="sparklogging" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">org.apache.spark.Logging</parameter></parameters>
+    <customMessage><![CDATA[Do not rely on Spark's Logging trait.]]></customMessage>
+  </check>
+
   <check customId="classforname" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">Class\.forName</parameter></parameters>
     <customMessage><![CDATA[

--- a/src/main/scala/com/databricks/spark/redshift/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/redshift/DefaultSource.scala
@@ -18,10 +18,10 @@ package com.databricks.spark.redshift
 
 import com.amazonaws.auth.AWSCredentials
 import com.amazonaws.services.s3.AmazonS3Client
-import org.apache.spark.Logging
 import org.apache.spark.sql.sources.{BaseRelation, CreatableRelationProvider, RelationProvider, SchemaRelationProvider}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode}
+import org.slf4j.LoggerFactory
 
 /**
  * Redshift Source implementation for Spark SQL
@@ -29,8 +29,9 @@ import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode}
 class DefaultSource(jdbcWrapper: JDBCWrapper, s3ClientFactory: AWSCredentials => AmazonS3Client)
   extends RelationProvider
   with SchemaRelationProvider
-  with CreatableRelationProvider
-  with Logging {
+  with CreatableRelationProvider {
+
+  private val log = LoggerFactory.getLogger(getClass)
 
   /**
    * Default constructor required by Data Source API

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftJDBCWrapper.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftJDBCWrapper.scala
@@ -23,14 +23,16 @@ import java.util.Properties
 import scala.util.Try
 
 import org.apache.spark.SPARK_VERSION
-import org.apache.spark.Logging
 import org.apache.spark.sql.types._
+import org.slf4j.LoggerFactory
 
 /**
  * Shim which exposes some JDBC helper functions. Most of this code is copied from Spark SQL, with
  * minor modifications for Redshift-specific features and limitations.
  */
-private[redshift] class JDBCWrapper extends Logging {
+private[redshift] class JDBCWrapper {
+
+  private val log = LoggerFactory.getLogger(getClass)
 
   def registerDriver(driverClass: String): Unit = {
     // DriverRegistry.register() is one of the few pieces of private Spark functionality which
@@ -114,7 +116,7 @@ private[redshift] class JDBCWrapper extends Logging {
       if (driver != null) registerDriver(driver)
     } catch {
       case e: ClassNotFoundException =>
-        logWarning(s"Couldn't find class $driver", e)
+        log.warn(s"Couldn't find class $driver", e)
     }
     DriverManager.getConnection(url, new Properties())
   }

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
@@ -20,13 +20,13 @@ import java.sql.{Connection, Date, SQLException, Timestamp}
 
 import com.amazonaws.auth.AWSCredentials
 import com.amazonaws.services.s3.AmazonS3Client
+import org.slf4j.LoggerFactory
 
 import scala.util.Random
 import scala.util.control.NonFatal
 
 import com.databricks.spark.redshift.Parameters.MergedParameters
 
-import org.apache.spark.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Row, SQLContext}
 import org.apache.spark.sql.types._
@@ -36,8 +36,9 @@ import org.apache.spark.sql.types._
  */
 private[redshift] class RedshiftWriter(
     jdbcWrapper: JDBCWrapper,
-    s3ClientFactory: AWSCredentials => AmazonS3Client)
-  extends Logging {
+    s3ClientFactory: AWSCredentials => AmazonS3Client) {
+
+  private val log = LoggerFactory.getLogger(getClass)
 
   /**
    * Generate CREATE TABLE statement for Redshift
@@ -164,7 +165,7 @@ private[redshift] class RedshiftWriter(
           }
         } catch {
           case NonFatal(e2) =>
-            logError("Error occurred while querying STL_LOAD_ERRORS", e2)
+            log.error("Error occurred while querying STL_LOAD_ERRORS", e2)
             None
         }
       throw detailedException.getOrElse(e)

--- a/src/main/scala/com/databricks/spark/redshift/Utils.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Utils.scala
@@ -23,15 +23,17 @@ import java.util.UUID
 import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
 
-import com.amazonaws.auth.{AWSCredentials, BasicAWSCredentials}
 import com.amazonaws.services.s3.{AmazonS3URI, AmazonS3Client}
 import com.amazonaws.services.s3.model.BucketLifecycleConfiguration
-import org.apache.spark.Logging
+import org.slf4j.LoggerFactory
 
 /**
  * Various arbitrary helper functions
  */
-private[redshift] object Utils extends Logging {
+private[redshift] object Utils {
+
+  private val log = LoggerFactory.getLogger(getClass)
+
   /**
    * Joins prefix URL a to path suffix b, and appends a trailing /, in order to create
    * a temp directory path for S3.
@@ -75,7 +77,7 @@ private[redshift] object Utils extends Logging {
         rule.getStatus == BucketLifecycleConfiguration.ENABLED && key.startsWith(rule.getPrefix)
       }
       if (!someRuleMatchesTempDir) {
-        logWarning(s"The S3 bucket $bucket does not have an object lifecycle configuration to " +
+        log.warn(s"The S3 bucket $bucket does not have an object lifecycle configuration to " +
           "ensure cleanup of temporary files. Consider configuring `tempdir` to point to a " +
           "bucket with an object lifecycle policy that automatically deletes files after an " +
           "expiration period. For more information, see " +
@@ -83,8 +85,7 @@ private[redshift] object Utils extends Logging {
       }
     } catch {
       case NonFatal(e) =>
-        logWarning(
-          "An error occurred while trying to read the S3 bucket lifecycle configuration", e)
+        log.warn("An error occurred while trying to read the S3 bucket lifecycle configuration", e)
     }
   }
 }


### PR DESCRIPTION
As a best-practice, third-party code should not rely on Spark's `Logging` trait. This patch refactors the code to remove this dependency and adds a Scalastyle rule to make sure that it's not re-introduced in new code.

Fixes #69.