### PR TITLE
Use a fresh temporary directory for each scan

### DIFF
--- a/src/it/scala/com/databricks/spark/redshift/RedshiftIntegrationSuite.scala
+++ b/src/it/scala/com/databricks/spark/redshift/RedshiftIntegrationSuite.scala
@@ -323,6 +323,17 @@ class RedshiftIntegrationSuite extends IntegrationSuiteBase {
     }
   }
 
+  test("multiple scans on same table") {
+    // .rdd() forces the first query to be unloaded from Redshift
+    val rdd1 = sqlContext.sql("select testint from test_table").rdd
+    // Similarly, this also forces an unload:
+    val rdd2 = sqlContext.sql("select testdouble from test_table").rdd
+    // If the unloads were performed into the same directory then this call would fail: the
+    // second unload from rdd2 would have overwritten the integers with doubles, so we'd get
+    // a NumberFormatException.
+    rdd1.count()
+  }
+
   test("configuring maxlength on string columns") {
     val tableName = s"configuring_maxlength_on_string_column_$randomSuffix"
     try {

--- a/src/main/scala/com/databricks/spark/redshift/Parameters.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Parameters.scala
@@ -70,12 +70,12 @@ private[redshift] object Parameters {
      * somewhere that can be written to and read from by Redshift. Make sure that AWS credentials
      * are available for S3.
      */
-    private def tempDir: String = parameters("tempdir")
+    def rootTempDir: String = parameters("tempdir")
 
     /**
-     * Each instance will create its own subdirectory in the tempDir, with a random UUID.
+     * Creates a per-query subdirectory in the [[rootTempDir]], with a random UUID.
      */
-    val tempPath: String = Utils.makeTempPath(tempDir)
+    def createPerQueryTempDir(): String = Utils.makeTempPath(rootTempDir)
 
     /**
      * The Redshift table to be used as the target when loading or writing data.

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
@@ -131,7 +131,7 @@ private[redshift] case class RedshiftRelation(
     }
     val fixedUrl = Utils.fixS3Url(tempDir)
 
-    s"UNLOAD ('$query') TO '$fixedUrl' WITH CREDENTIALS '$credsString' ESCAPE ALLOWOVERWRITE"
+    s"UNLOAD ('$query') TO '$fixedUrl' WITH CREDENTIALS '$credsString' ESCAPE"
   }
 
   private def pruneSchema(schema: StructType, columns: Array[String]): StructType = {

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
@@ -61,8 +61,8 @@ private[redshift] case class RedshiftRelation(
 
   override def buildScan(requiredColumns: Array[String], filters: Array[Filter]): RDD[Row] = {
     val creds =
-      AWSCredentialsUtils.load(params.tempPath, sqlContext.sparkContext.hadoopConfiguration)
-    Utils.checkThatBucketHasObjectLifecycleConfiguration(params.tempPath, s3ClientFactory(creds))
+      AWSCredentialsUtils.load(params.rootTempDir, sqlContext.sparkContext.hadoopConfiguration)
+    Utils.checkThatBucketHasObjectLifecycleConfiguration(params.rootTempDir, s3ClientFactory(creds))
     if (requiredColumns.isEmpty) {
       // In the special case where no columns were requested, issue a `count(*)` against Redshift
       // rather than unloading data.
@@ -86,7 +86,8 @@ private[redshift] case class RedshiftRelation(
       }
     } else {
       // Unload data from Redshift into a temporary directory in S3:
-      val unloadSql = buildUnloadStmt(requiredColumns, filters)
+      val tempDir = params.createPerQueryTempDir()
+      val unloadSql = buildUnloadStmt(requiredColumns, filters, tempDir)
       log.info(unloadSql)
       val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl)
       try {
@@ -96,7 +97,7 @@ private[redshift] case class RedshiftRelation(
       }
       // Create a DataFrame to read the unloaded data:
       val rdd = sqlContext.sparkContext.newAPIHadoopFile(
-        params.tempPath,
+        tempDir,
         classOf[RedshiftInputFormat],
         classOf[java.lang.Long],
         classOf[Array[String]])
@@ -108,13 +109,16 @@ private[redshift] case class RedshiftRelation(
     }
   }
 
-  private def buildUnloadStmt(requiredColumns: Array[String], filters: Array[Filter]): String = {
+  private def buildUnloadStmt(
+      requiredColumns: Array[String],
+      filters: Array[Filter],
+      tempDir: String): String = {
     assert(!requiredColumns.isEmpty)
     // Always quote column names:
     val columnList = requiredColumns.map(col => s""""$col"""").mkString(", ")
     val whereClause = FilterPushdown.buildWhereClause(schema, filters)
     val creds = params.temporaryAWSCredentials.getOrElse(
-      AWSCredentialsUtils.load(params.tempPath, sqlContext.sparkContext.hadoopConfiguration))
+      AWSCredentialsUtils.load(params.rootTempDir, sqlContext.sparkContext.hadoopConfiguration))
     val credsString: String = AWSCredentialsUtils.getRedshiftCredentialsString(creds)
     val query = {
       // Since the query passed to UNLOAD will be enclosed in single quotes, we need to escape
@@ -125,7 +129,7 @@ private[redshift] case class RedshiftRelation(
       }
       s"SELECT $columnList FROM $tableNameOrSubquery $whereClause"
     }
-    val fixedUrl = Utils.fixS3Url(params.tempPath)
+    val fixedUrl = Utils.fixS3Url(tempDir)
 
     s"UNLOAD ('$query') TO '$fixedUrl' WITH CREDENTIALS '$credsString' ESCAPE ALLOWOVERWRITE"
   }

--- a/src/test/scala/com/databricks/spark/redshift/ParametersSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/ParametersSuite.scala
@@ -31,7 +31,8 @@ class ParametersSuite extends FunSuite with Matchers {
 
     val mergedParams = Parameters.mergeParameters(params)
 
-    mergedParams.tempPath should startWith (params("tempdir"))
+    mergedParams.rootTempDir should startWith (params("tempdir"))
+    mergedParams.createPerQueryTempDir() should startWith (params("tempdir"))
     mergedParams.jdbcUrl shouldBe params("url")
     mergedParams.table shouldBe Some(params("dbtable"))
 
@@ -41,16 +42,15 @@ class ParametersSuite extends FunSuite with Matchers {
     }
   }
 
-  test("New instances have distinct temp paths") {
+  test("createPerQueryTempDir() returns distinct temp paths") {
     val params = Map(
       "tempdir" -> "s3://foo/bar",
       "dbtable" -> "test_table",
       "url" -> "jdbc:redshift://foo/bar")
 
-    val mergedParams1 = Parameters.mergeParameters(params)
-    val mergedParams2 = Parameters.mergeParameters(params)
+    val mergedParams = Parameters.mergeParameters(params)
 
-    mergedParams1.tempPath should not equal mergedParams2.tempPath
+    mergedParams.createPerQueryTempDir() should not equal mergedParams.createPerQueryTempDir()
   }
 
   test("Errors are thrown when mandatory parameters are not provided") {

--- a/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
@@ -185,7 +185,7 @@ class RedshiftSourceSuite
       "FROM test_table '\\) " +
       "TO '.*' " +
       "WITH CREDENTIALS 'aws_access_key_id=test1;aws_secret_access_key=test2' " +
-      "ESCAPE ALLOWOVERWRITE").r
+      "ESCAPE").r
     val jdbcWrapper = prepareUnloadTest(defaultParams, Seq(expectedQuery))
 
     // Assert that we've loaded and converted all data in the test file
@@ -250,7 +250,7 @@ class RedshiftSourceSuite
       "UNLOAD \\('SELECT \"testbyte\", \"testbool\" FROM test_table '\\) " +
       "TO '.*' " +
       "WITH CREDENTIALS 'aws_access_key_id=test1;aws_secret_access_key=test2' " +
-      "ESCAPE ALLOWOVERWRITE").r
+      "ESCAPE").r
     val jdbcWrapper = prepareUnloadTest(defaultParams, Seq(expectedQuery))
     // Construct the source with a custom schema
     val source = new DefaultSource(jdbcWrapper, _ => mockS3Client)
@@ -280,7 +280,7 @@ class RedshiftSourceSuite
         "AND \"testint\" <= 43'\\) " +
       "TO '.*' " +
       "WITH CREDENTIALS 'aws_access_key_id=test1;aws_secret_access_key=test2' " +
-      "ESCAPE ALLOWOVERWRITE").r
+      "ESCAPE").r
     // scalastyle:on
     val jdbcWrapper = prepareUnloadTest(defaultParams, Seq(expectedQuery))
 


### PR DESCRIPTION
This patch fixes a bug where multiple scans of the same relation would end up sharing the same temporary directory in S3, causing them to overwrite each others' data. This, in turn, led to exceptions during query execution.

This patch fixes this bug by creating a fresh subdirectory inside of the temporary directory for each scan.