### PR TITLE
Throw exception when using S3 Block FileSystem

### DIFF
--- a/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
@@ -45,7 +45,7 @@ private[redshift] case class RedshiftRelation(
   private val log = LoggerFactory.getLogger(getClass)
 
   if (sqlContext != null) {
-    Utils.assertThatFileSystemIsNotS3BlockStore(
+    Utils.assertThatFileSystemIsNotS3BlockFileSystem(
       new URI(params.rootTempDir), sqlContext.sparkContext.hadoopConfiguration)
   }
 

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
@@ -16,6 +16,8 @@
 
 package com.databricks.spark.redshift
 
+import java.net.URI
+
 import com.amazonaws.auth.AWSCredentials
 import com.amazonaws.services.s3.AmazonS3Client
 import org.apache.hadoop.conf.Configuration
@@ -41,6 +43,11 @@ private[redshift] case class RedshiftRelation(
   with InsertableRelation {
 
   private val log = LoggerFactory.getLogger(getClass)
+
+  if (sqlContext != null) {
+    Utils.assertThatFileSystemIsNotS3BlockStore(
+      new URI(params.rootTempDir), sqlContext.sparkContext.hadoopConfiguration)
+  }
 
   override def schema: StructType = {
     userSchema match {

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
@@ -266,7 +266,7 @@ private[redshift] class RedshiftWriter(
         "For save operations you must specify a Redshift table name with the 'dbtable' parameter")
     }
 
-    Utils.assertThatFileSystemIsNotS3BlockStore(
+    Utils.assertThatFileSystemIsNotS3BlockFileSystem(
       new URI(params.rootTempDir), sqlContext.sparkContext.hadoopConfiguration)
 
     val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl)

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
@@ -16,6 +16,7 @@
 
 package com.databricks.spark.redshift
 
+import java.net.URI
 import java.sql.{Connection, Date, SQLException, Timestamp}
 
 import com.amazonaws.auth.AWSCredentials
@@ -264,6 +265,9 @@ private[redshift] class RedshiftWriter(
       throw new IllegalArgumentException(
         "For save operations you must specify a Redshift table name with the 'dbtable' parameter")
     }
+
+    Utils.assertThatFileSystemIsNotS3BlockStore(
+      new URI(params.rootTempDir), sqlContext.sparkContext.hadoopConfiguration)
 
     val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl)
 

--- a/src/main/scala/com/databricks/spark/redshift/Utils.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Utils.scala
@@ -93,11 +93,11 @@ private[redshift] object Utils {
   }
 
   /**
-   * Given a URI, verify that the Hadoop FileSystem for that URI is not the classic S3 block storage
-   * filesystem. `spark-redshift` cannot use this FileSystem because the files written to it will
-   * not be readable by Redshift (and vice versa).
+   * Given a URI, verify that the Hadoop FileSystem for that URI is not the S3 block FileSystem.
+   * `spark-redshift` cannot use this FileSystem because the files written to it will not be
+   * readable by Redshift (and vice versa).
    */
-  def assertThatFileSystemIsNotS3BlockStore(uri: URI, hadoopConfig: Configuration): Unit = {
+  def assertThatFileSystemIsNotS3BlockFileSystem(uri: URI, hadoopConfig: Configuration): Unit = {
     val fs = FileSystem.get(uri, hadoopConfig)
     // Note that we do not want to use isInstanceOf here, since we're only interested in detecting
     // exact matches

--- a/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
@@ -538,4 +538,20 @@ class RedshiftSourceSuite
   test("DefaultSource has default constructor, required by Data Source API") {
     new DefaultSource()
   }
+
+  test("Saves throw error message if S3 Block FileSystem would be used") {
+    val params = defaultParams + ("tempdir" -> defaultParams("tempdir").replace("s3n", "s3"))
+    val e = intercept[IllegalArgumentException] {
+      expectedDataDF.saveAsRedshiftTable(params)
+    }
+    assert(e.getMessage.contains("Block FileSystem"))
+  }
+
+  test("Loads throw error message if S3 Block FileSystem would be used") {
+    val params = defaultParams + ("tempdir" -> defaultParams("tempdir").replace("s3n", "s3"))
+    val e = intercept[IllegalArgumentException] {
+      testSqlContext.read.format("com.databricks.spark.redshift").options(params).load()
+    }
+    assert(e.getMessage.contains("Block FileSystem"))
+  }
 }

--- a/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
@@ -98,6 +98,8 @@ class RedshiftSourceSuite
     // while using the mocked S3 filesystem.
     sc.hadoopConfiguration.set("spark.sql.sources.outputCommitterClass",
       classOf[DirectOutputCommitter].getName)
+    sc.hadoopConfiguration.set("fs.s3.awsAccessKeyId", "test1")
+    sc.hadoopConfiguration.set("fs.s3.awsSecretAccessKey", "test2")
     sc.hadoopConfiguration.set("fs.s3n.awsAccessKeyId", "test1")
     sc.hadoopConfiguration.set("fs.s3n.awsSecretAccessKey", "test2")
     // Configure a mock S3 client so that we don't hit errors when trying to access AWS in tests.


### PR DESCRIPTION
This patch extends `spark-redshift` to throw exceptions if the `tempdir` URI would create a S3 Block Filesystem. `spark-redshift` will only work with S3 Native FileSystems.

See #38 for more background discussion of this issue.