### PR TITLE
Prepare for Maven publishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,16 +12,20 @@ matrix:
     # https://github.com/apache/spark/pull/6599 is not present in 1.4.1,
     # so the published Spark Maven artifacts will not work with Hadoop 1.x.
     - jdk: openjdk6
-      scala: 2.10.4
+      scala: 2.10.5
       env: HADOOP_VERSION="2.2.0" SPARK_VERSION="1.4.1"
     - jdk: openjdk7
-      scala: 2.10.4
+      scala: 2.10.5
       env: HADOOP_VERSION="1.0.4" SPARK_VERSION="1.5.0-rc3"
     - jdk: openjdk7
-      scala: 2.10.4
+      scala: 2.10.5
       env: HADOOP_VERSION="1.2.1" SPARK_VERSION="1.5.0-rc3"
     - jdk: openjdk7
-      scala: 2.10.4
+      scala: 2.10.5
+      env: HADOOP_VERSION="2.2.0" SPARK_VERSION="1.5.0-rc3"
+    # Scala 2.11 tests:
+    - jdk: openjdk7
+      scala: 2.11.7
       env: HADOOP_VERSION="2.2.0" SPARK_VERSION="1.5.0-rc3"
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,10 +45,10 @@ env:
     - secure: "LvndQIW6dHs6nyaMHtblGI/oL+s460lOezFs2BoD0Isenb/O/IM+nY5K9HepTXjJIcq8qvUYnojZX1FCrxxOXX2/+/Iihiq7GzJYdmdMC6hLg9bJYeAFk0dWYT88/AwadrJCBOa3ockRLhiO3dkai7Ki5+M1erfaFiAHHMpJxYQ="
 
 script:
-  - sbt -Dhadoop.testVersion=$HADOOP_VERSION -Dspark.testVersion=$SPARK_VERSION coverage test
-  - if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then sbt -Dhadoop.version=$HADOOP_VERSION -Dspark.version=$SPARK_VERSION coverage it:test 2> /dev/null; fi
-  - sbt scalastyle
-  - sbt "test:scalastyle"
-  - sbt "it:scalastyle"
+  - sbt -Dhadoop.testVersion=$HADOOP_VERSION -Dspark.testVersion=$SPARK_VERSION ++$TRAVIS_SCALA_VERSION coverage test
+  - if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then sbt -Dhadoop.version=$HADOOP_VERSION -Dspark.version=$SPARK_VERSION ++$TRAVIS_SCALA_VERSION coverage it:test 2> /dev/null; fi
+  - sbt ++$TRAVIS_SCALA_VERSION scalastyle
+  - sbt ++$TRAVIS_SCALA_VERSION "test:scalastyle"
+  - sbt ++$TRAVIS_SCALA_VERSION  "it:scalastyle"
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/project/SparkRedshiftBuild.scala
+++ b/project/SparkRedshiftBuild.scala
@@ -40,7 +40,7 @@ object SparkRedshiftBuild extends Build {
     .settings(
       name := "spark-redshift",
       organization := "com.databricks",
-      scalaVersion := "2.10.4",
+      scalaVersion := "2.10.5",
       crossScalaVersions := Seq("2.10.5", "2.11.7"),
       sparkVersion := "1.4.1",
       testSparkVersion := sys.props.get("spark.testVersion").getOrElse(sparkVersion.value),

--- a/project/SparkRedshiftBuild.scala
+++ b/project/SparkRedshiftBuild.scala
@@ -70,7 +70,7 @@ object SparkRedshiftBuild extends Build {
         "com.amazonaws" % "aws-java-sdk-sts" % "1.9.40" % "test",
         // We require spark-avro, but avro-mapred must be provided to match Hadoop version.
         // In most cases, avro-mapred will be provided as part of the Spark assembly JAR.
-        "com.databricks" %% "spark-avro" % "2.0.0",
+        "com.databricks" %% "spark-avro" % "2.0.1",
         if (testHadoopVersion.value.startsWith("1")) {
           "org.apache.avro" % "avro-mapred" % "1.7.7" % "provided" classifier "hadoop1" exclude("org.mortbay.jetty", "servlet-api")
         } else {

--- a/project/SparkRedshiftBuild.scala
+++ b/project/SparkRedshiftBuild.scala
@@ -135,13 +135,6 @@ object SparkRedshiftBuild extends Build {
 
       pomExtra :=
         <url>https://github.com/databricks/spark-redshift</url>
-        <licenses>
-          <license>
-            <name>Apache License, Verision 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
-            <distribution>repo</distribution>
-          </license>
-        </licenses>
         <scm>
           <url>git@github.com:databricks/spark-redshift.git</url>
           <connection>scm:git:git@github.com:databricks/spark-redshift.git</connection>
@@ -153,9 +146,9 @@ object SparkRedshiftBuild extends Build {
             <url>https://github.com/mengxr</url>
           </developer>
           <developer>
-            <id>joshrosen</id>
+            <id>JoshRosen</id>
             <name>Josh Rosen</name>
-            <url>https://github.com/joshrosen</url>
+            <url>https://github.com/JoshRosen</url>
           </developer>
           <developer>
             <id>marmbrus</id>

--- a/project/SparkRedshiftBuild.scala
+++ b/project/SparkRedshiftBuild.scala
@@ -170,8 +170,7 @@ object SparkRedshiftBuild extends Build {
         publishArtifacts,
         setNextVersion,
         commitNextVersion,
-        pushChanges,
-        releaseStepTask(spPublish)
+        pushChanges
       )
     )
 }

--- a/project/SparkRedshiftBuild.scala
+++ b/project/SparkRedshiftBuild.scala
@@ -168,10 +168,10 @@ object SparkRedshiftBuild extends Build {
         commitReleaseVersion,
         tagRelease,
         publishArtifacts,
-        releaseStepTask(spPublish),
         setNextVersion,
         commitNextVersion,
-        pushChanges
+        pushChanges,
+        releaseStepTask(spPublish)
       )
     )
 }


### PR DESCRIPTION
This PR modifies our build to prepare for Maven release publishing.

- Fix duplicate license in generated POM.
- Use `spark-avro` 2.0.1, which is available on Maven Central.
- Add a Scala 2.11 build to the to Travis test matrix.
- Publish package after pushing.