### PR TITLE
Refactor handling of SaveModes and overwrite parameter

### DIFF
--- a/src/main/scala/com/databricks/spark/redshift/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/redshift/DefaultSource.scala
@@ -65,7 +65,7 @@ class DefaultSource(jdbcWrapper: JDBCWrapper, s3ClientFactory: AWSCredentials =>
    */
   override def createRelation(
       sqlContext: SQLContext,
-      mode: SaveMode,
+      saveMode: SaveMode,
       parameters: Map[String, String],
       data: DataFrame): BaseRelation = {
     val params = Parameters.mergeParameters(parameters)
@@ -81,7 +81,7 @@ class DefaultSource(jdbcWrapper: JDBCWrapper, s3ClientFactory: AWSCredentials =>
       exists
     }
 
-    val (doSave, dropExisting) = mode match {
+    val (doSave, dropExisting) = saveMode match {
       case SaveMode.Append => (true, false)
       case SaveMode.Overwrite => (true, true)
       case SaveMode.ErrorIfExists =>
@@ -102,7 +102,7 @@ class DefaultSource(jdbcWrapper: JDBCWrapper, s3ClientFactory: AWSCredentials =>
     if (doSave) {
       val updatedParams = parameters.updated("overwrite", dropExisting.toString)
       new RedshiftWriter(jdbcWrapper, s3ClientFactory).saveToRedshift(
-        sqlContext, data, Parameters.mergeParameters(updatedParams))
+        sqlContext, data, saveMode, Parameters.mergeParameters(updatedParams))
     }
 
     createRelation(sqlContext, parameters)

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
@@ -22,7 +22,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types._
-import org.apache.spark.sql.{DataFrame, Row, SQLContext}
+import org.apache.spark.sql.{DataFrame, Row, SaveMode, SQLContext}
 import org.slf4j.LoggerFactory
 
 import com.databricks.spark.redshift.Parameters.MergedParameters
@@ -54,9 +54,13 @@ private[redshift] case class RedshiftRelation(
   }
 
   override def insert(data: DataFrame, overwrite: Boolean): Unit = {
-    val updatedParams =
-      Parameters.mergeParameters(params.parameters updated ("overwrite", overwrite.toString))
-    new RedshiftWriter(jdbcWrapper, s3ClientFactory).saveToRedshift(sqlContext, data, updatedParams)
+    val saveMode = if (overwrite) {
+      SaveMode.Overwrite
+    } else {
+      SaveMode.Append
+    }
+    val writer = new RedshiftWriter(jdbcWrapper, s3ClientFactory)
+    writer.saveToRedshift(sqlContext, data, saveMode, params)
   }
 
   override def buildScan(requiredColumns: Array[String], filters: Array[Filter]): RDD[Row] = {

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
@@ -28,7 +28,7 @@ import scala.util.control.NonFatal
 import com.databricks.spark.redshift.Parameters.MergedParameters
 
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{DataFrame, Row, SQLContext}
+import org.apache.spark.sql.{DataFrame, Row, SaveMode, SQLContext}
 import org.apache.spark.sql.types._
 
 /**
@@ -116,11 +116,12 @@ private[redshift] class RedshiftWriter(
   private def doRedshiftLoad(
       conn: Connection,
       data: DataFrame,
+      saveMode: SaveMode,
       params: MergedParameters,
       tempDir: String): Unit = {
 
     // Overwrites must drop the table, in case there has been a schema update
-    if (params.overwrite) {
+    if (saveMode == SaveMode.Overwrite) {
       val deleteExisting = conn.prepareStatement(s"DROP TABLE IF EXISTS ${params.table.get}")
       deleteExisting.execute()
     }
@@ -259,7 +260,11 @@ private[redshift] class RedshiftWriter(
   /**
    * Write a DataFrame to a Redshift table, using S3 and Avro serialization
    */
-  def saveToRedshift(sqlContext: SQLContext, data: DataFrame, params: MergedParameters) : Unit = {
+  def saveToRedshift(
+      sqlContext: SQLContext,
+      data: DataFrame,
+      saveMode: SaveMode,
+      params: MergedParameters) : Unit = {
     if (params.table.isEmpty) {
       throw new IllegalArgumentException(
         "For save operations you must specify a Redshift table name with the 'dbtable' parameter")
@@ -269,15 +274,15 @@ private[redshift] class RedshiftWriter(
 
     val tempDir = params.createPerQueryTempDir()
     try {
-      if (params.overwrite && params.useStagingTable) {
+      if (saveMode == SaveMode.Overwrite && params.useStagingTable) {
         withStagingTable(conn, params.table.get, stagingTable => {
           val updatedParams = MergedParameters(params.parameters.updated("dbtable", stagingTable))
           unloadData(sqlContext, data, updatedParams, tempDir)
-          doRedshiftLoad(conn, data, updatedParams, tempDir)
+          doRedshiftLoad(conn, data, saveMode, updatedParams, tempDir)
         })
       } else {
         unloadData(sqlContext, data, params, tempDir)
-        doRedshiftLoad(conn, data, params, tempDir)
+        doRedshiftLoad(conn, data, saveMode, params, tempDir)
       }
     } finally {
       conn.close()

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
@@ -94,12 +94,12 @@ private[redshift] class RedshiftWriter(
       if (jdbcWrapper.tableExists(conn, table)) {
         conn.prepareStatement(
           s"""
-             | begin;
-             | ALTER TABLE $table RENAME TO $backupTable";
+             | BEGIN;
+             | ALTER TABLE $table RENAME TO $backupTable;
              | ALTER TABLE $tempTable RENAME TO $table;
              | DROP TABLE $backupTable;
-             | end;
-           """.stripMargin).execute()
+             | END;
+           """.stripMargin.trim).execute()
       } else {
         conn.prepareStatement(s"ALTER TABLE $tempTable RENAME TO $table").execute()
       }

--- a/src/main/scala/com/databricks/spark/redshift/package.scala
+++ b/src/main/scala/com/databricks/spark/redshift/package.scala
@@ -20,7 +20,7 @@ package com.databricks.spark
 import com.amazonaws.services.s3.AmazonS3Client
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
-import org.apache.spark.sql.{DataFrame, DataFrameReader, DataFrameWriter, Row, SQLContext}
+import org.apache.spark.sql.{DataFrame, DataFrameReader, DataFrameWriter, Row, SaveMode, SQLContext}
 
 package object redshift {
 
@@ -76,12 +76,19 @@ package object redshift {
   implicit class RedshiftDataFrame(dataFrame: DataFrame) {
 
     /**
-     * Load the DataFrame into a Redshift database table
+     * Load the DataFrame into a Redshift database table. By default, this will append to the
+     * specified table. If the `overwrite` parameter is set to `true` then this will drop the
+     * existing table and re-create it with the contents of this DataFrame.
      */
     @deprecated("Use DataFrame.write()", "0.5.0")
     def saveAsRedshiftTable(parameters: Map[String, String]): Unit = {
       val params = Parameters.mergeParameters(parameters)
-      DefaultRedshiftWriter.saveToRedshift(dataFrame.sqlContext, dataFrame, params)
+      val saveMode = if (params.overwrite) {
+        SaveMode.Overwrite
+      } else {
+        SaveMode.Append
+      }
+      DefaultRedshiftWriter.saveToRedshift(dataFrame.sqlContext, dataFrame, saveMode, params)
     }
   }
 }

--- a/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
@@ -359,7 +359,8 @@ class RedshiftSourceSuite
     val writer = new RedshiftWriter(jdbcWrapper, _ => mockS3Client)
 
     intercept[IllegalArgumentException] {
-      writer.saveToRedshift(testSqlContext, df, Parameters.mergeParameters(defaultParams))
+      writer.saveToRedshift(
+        testSqlContext, df, SaveMode.Append, Parameters.mergeParameters(defaultParams))
     }
   }
 


### PR DESCRIPTION
This patch performs refactoring and cleanup related to `spark-redshift`'s handling of SaveModes and its `overwrite` configuration parameter.

- The `overwrite` parameter is no longer used internally; instead, it's used at the edges of the API to pick an appropriate `SaveMode` setting. This is important because this parameter is deprecated and is slated to be removed in 0.6.0.
- Use a transaction to atomically swap the temporary table and backup table when performing overwrites with a staging table.

Fixes #68.