### PR TITLE
Quote column names in JDBC schemaString

### DIFF
--- a/src/it/scala/com/databricks/spark/redshift/RedshiftIntegrationSuite.scala
+++ b/src/it/scala/com/databricks/spark/redshift/RedshiftIntegrationSuite.scala
@@ -336,6 +336,14 @@ class RedshiftIntegrationSuite extends IntegrationSuiteBase {
         .mode(SaveMode.ErrorIfExists)
         .save()
       assert(DefaultJDBCWrapper.tableExists(conn, tableName))
+      val loadedDf = sqlContext.read
+        .format("com.databricks.spark.redshift")
+        .option("url", jdbcUrl)
+        .option("dbtable", tableName)
+        .option("tempdir", tempDir)
+        .load()
+      assert(loadedDf.schema === df.schema)
+      checkAnswer(loadedDf, Seq(Row(1)))
     } finally {
       conn.prepareStatement(s"drop table if exists $tableName").executeUpdate()
       conn.commit()

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftJDBCWrapper.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftJDBCWrapper.scala
@@ -89,9 +89,8 @@ private[redshift] class JDBCWrapper {
           val fieldScale = rsmd.getScale(i + 1)
           val isSigned = rsmd.isSigned(i + 1)
           val nullable = rsmd.isNullable(i + 1) != ResultSetMetaData.columnNoNulls
-          val metadata = new MetadataBuilder().putString("name", columnName)
           val columnType = getCatalystType(dataType, fieldSize, fieldScale, isSigned)
-          fields(i) = StructField(columnName, columnType, nullable, metadata.build())
+          fields(i) = StructField(columnName, columnType, nullable)
           i = i + 1
         }
         return new StructType(fields)

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftJDBCWrapper.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftJDBCWrapper.scala
@@ -149,7 +149,7 @@ private[redshift] class JDBCWrapper {
         case _ => throw new IllegalArgumentException(s"Don't know how to save $field to JDBC")
       }
       val nullable = if (field.nullable) "" else "NOT NULL"
-      sb.append(s", $name $typ $nullable".trim)
+      sb.append(s""", "${name.replace("\"", "\\\"")}" $typ $nullable""".trim)
     }}
     if (sb.length < 2) "" else sb.substring(2)
   }

--- a/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
@@ -476,8 +476,8 @@ class RedshiftSourceSuite
     val createTableCommand =
       DefaultRedshiftWriter.createTableSql(df, MergedParameters.apply(defaultParams)).trim
     val expectedCreateTableCommand =
-      "CREATE TABLE IF NOT EXISTS test_table (long_str VARCHAR(512), short_str VARCHAR(10), " +
-        "default_str TEXT)"
+      """CREATE TABLE IF NOT EXISTS test_table ("long_str" VARCHAR(512),""" +
+        """ "short_str" VARCHAR(10), "default_str" TEXT)"""
     assert(createTableCommand === expectedCreateTableCommand)
   }
 

--- a/src/test/scala/com/databricks/spark/redshift/TestUtils.scala
+++ b/src/test/scala/com/databricks/spark/redshift/TestUtils.scala
@@ -31,22 +31,18 @@ object TestUtils {
    * Simple schema that includes all data types we support
    */
   val testSchema: StructType = {
-    def makeField(name: String, typ: DataType) = {
-      val md = (new MetadataBuilder).putString("name", name).build()
-      StructField(name, typ, nullable = true, metadata = md)
-    }
     // These column names need to be lowercase; see #51
     StructType(Seq(
-      makeField("testbyte", ByteType),
-      makeField("testbool", BooleanType),
-      makeField("testdate", DateType),
-      makeField("testdouble", DoubleType),
-      makeField("testfloat", FloatType),
-      makeField("testint", IntegerType),
-      makeField("testlong", LongType),
-      makeField("testshort", ShortType),
-      makeField("teststring", StringType),
-      makeField("testtimestamp", TimestampType)))
+      StructField("testbyte", ByteType),
+      StructField("testbool", BooleanType),
+      StructField("testdate", DateType),
+      StructField("testdouble", DoubleType),
+      StructField("testfloat", FloatType),
+      StructField("testint", IntegerType),
+      StructField("testlong", LongType),
+      StructField("testshort", ShortType),
+      StructField("teststring", StringType),
+      StructField("testtimestamp", TimestampType)))
   }
 
   // scalastyle:off


### PR DESCRIPTION
This patch modifies `JDBCWrapper.schemaString` to wrap column names in quotes, which is necessary in order to allow us to create tables with columns whose names are reserved words or which contain spaces. This fixes #80.

Note that, by itself, this patch does not enable full support for creating Redshift tables with column names that contain spaces; we are currently constrained by Avro's schema validation rules (see #84).