### PR TITLE
Refactor RedshiftSourceSuite to remove use of ScalaMock

### DIFF
--- a/project/SparkRedshiftBuild.scala
+++ b/project/SparkRedshiftBuild.scala
@@ -81,7 +81,6 @@ object SparkRedshiftBuild extends Build {
         "com.amazon.redshift" % "jdbc4" % "1.1.7.1007" % "test" from "https://s3.amazonaws.com/redshift-downloads/drivers/RedshiftJDBC4-1.1.7.1007.jar",
         "com.google.guava" % "guava" % "14.0.1" % "test",
         "org.scalatest" %% "scalatest" % "2.2.1" % "test",
-        "org.scalamock" %% "scalamock-scalatest-support" % "3.2" % "test",
         "org.mockito" % "mockito-core" % "1.10.19" % "test"
       ),
       libraryDependencies ++= (if (testHadoopVersion.value.startsWith("1")) {

--- a/src/main/scala/com/databricks/spark/redshift/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/redshift/DefaultSource.scala
@@ -76,9 +76,11 @@ class DefaultSource(jdbcWrapper: JDBCWrapper, s3ClientFactory: AWSCredentials =>
 
     def tableExists: Boolean = {
       val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl)
-      val exists = jdbcWrapper.tableExists(conn, table)
-      conn.close()
-      exists
+      try {
+        jdbcWrapper.tableExists(conn, table)
+      } finally {
+        conn.close()
+      }
     }
 
     val (doSave, dropExisting) = saveMode match {

--- a/src/test/scala/com/databricks/spark/redshift/MockRedshift.scala
+++ b/src/test/scala/com/databricks/spark/redshift/MockRedshift.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2015 Databricks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.databricks.spark.redshift
+
+import java.sql.{SQLException, PreparedStatement, Connection}
+
+import scala.collection.mutable
+import scala.util.matching.Regex
+
+import org.apache.spark.sql.types.StructType
+import org.mockito.Matchers._
+import org.mockito.Mockito._
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.Answer
+import org.scalatest.Assertions._
+
+
+/**
+ * Helper class for mocking Redshift / JDBC in unit tests.
+ */
+class MockRedshift(
+    jdbcUrl: String,
+    existingTablesAndSchemas: Map[String, StructType],
+    jdbcQueriesThatShouldFail: Seq[Regex] = Seq.empty) {
+
+  private[this] val queriesIssued: mutable.Buffer[String] = mutable.Buffer.empty
+  def getQueriesIssuedAgainstRedshift: Seq[String] = queriesIssued.toSeq
+
+  private[this] val jdbcConnections: mutable.Buffer[Connection] = mutable.Buffer.empty
+
+  val jdbcWrapper: JDBCWrapper = mock(classOf[JDBCWrapper], RETURNS_SMART_NULLS)
+
+  private def createMockConnection(): Connection = {
+    val conn = mock(classOf[Connection], RETURNS_SMART_NULLS)
+    jdbcConnections.append(conn)
+    when(conn.prepareStatement(anyString())).thenAnswer(new Answer[PreparedStatement] {
+      override def answer(invocation: InvocationOnMock): PreparedStatement = {
+        val query = invocation.getArguments()(0).asInstanceOf[String]
+        queriesIssued.append(query)
+        val mockStatement = mock(classOf[PreparedStatement], RETURNS_SMART_NULLS)
+        if (jdbcQueriesThatShouldFail.forall(_.findFirstMatchIn(query).isEmpty)) {
+          when(mockStatement.execute()).thenReturn(true)
+        } else {
+          when(mockStatement.execute()).thenThrow(new SQLException(s"Error executing $query"))
+        }
+        mockStatement
+      }
+    })
+    conn
+  }
+
+  when(jdbcWrapper.getConnector(anyString(), same(jdbcUrl))).thenAnswer(new Answer[Connection] {
+    override def answer(invocation: InvocationOnMock): Connection = createMockConnection()
+  })
+
+  when(jdbcWrapper.tableExists(any[Connection], anyString())).thenAnswer(new Answer[Boolean] {
+    override def answer(invocation: InvocationOnMock): Boolean = {
+      existingTablesAndSchemas.contains(invocation.getArguments()(1).asInstanceOf[String])
+    }
+  })
+
+  when(jdbcWrapper.resolveTable(same(jdbcUrl), anyString())).thenAnswer(new Answer[StructType] {
+    override def answer(invocation: InvocationOnMock): StructType = {
+      existingTablesAndSchemas(invocation.getArguments()(1).asInstanceOf[String])
+    }
+  })
+
+  def verifyThatConnectionsWereClosed(): Unit = {
+    jdbcConnections.foreach { conn =>
+      verify(conn).close()
+    }
+  }
+
+  def verifyThatExpectedQueriesWereIssued(expectedQueries: Seq[Regex]): Unit = {
+    expectedQueries.zip(queriesIssued).foreach { case (expected, actual) =>
+      if (expected.findFirstMatchIn(actual).isEmpty) {
+        fail(
+          s"""
+             |Actual and expected JDBC queries did not match:
+             |Expected: $expected
+             |Actual: $actual
+           """.stripMargin)
+      }
+    }
+    if (expectedQueries.length > queriesIssued.length) {
+      val missingQueries = expectedQueries.drop(queriesIssued.length)
+      fail(s"Missing ${missingQueries.length} expected JDBC queries:" +
+        s"\n${missingQueries.mkString("\n")}")
+    } else if (queriesIssued.length > expectedQueries.length) {
+      val extraQueries = queriesIssued.drop(expectedQueries.length)
+      fail(s"Got ${extraQueries.length} unexpected JDBC queries:\n${extraQueries.mkString("\n")}")
+    }
+  }
+}

--- a/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
@@ -18,19 +18,17 @@ package com.databricks.spark.redshift
 
 import java.io.File
 import java.net.URI
-import java.sql.{Connection, PreparedStatement, SQLException}
-
-import scala.util.matching.Regex
 
 import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.s3.model.BucketLifecycleConfiguration
 import com.amazonaws.services.s3.model.BucketLifecycleConfiguration.Rule
+import org.mockito.Matchers._
 import org.mockito.Mockito
+import org.mockito.Mockito.when
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.mapreduce.InputFormat
 import org.apache.hadoop.fs.{Path, FileSystem}
 import org.apache.hadoop.fs.s3native.S3NInMemoryFileSystem
-import org.scalamock.scalatest.MockFactory
 import org.scalatest.{BeforeAndAfterEach, BeforeAndAfterAll, Matchers}
 
 import org.apache.spark.SparkContext
@@ -64,7 +62,6 @@ private class TestContext extends SparkContext("local", "RedshiftSourceSuite") {
 class RedshiftSourceSuite
   extends QueryTest
   with Matchers
-  with MockFactory
   with BeforeAndAfterAll
   with BeforeAndAfterEach {
 
@@ -103,11 +100,9 @@ class RedshiftSourceSuite
     sc.hadoopConfiguration.set("fs.s3n.awsAccessKeyId", "test1")
     sc.hadoopConfiguration.set("fs.s3n.awsSecretAccessKey", "test2")
     // Configure a mock S3 client so that we don't hit errors when trying to access AWS in tests.
-    // ScalaMock cannot mock classes which contain final methods, even if the classes themselves
-    // are not final, so we use Mockito instead:
     mockS3Client = Mockito.mock(classOf[AmazonS3Client], Mockito.RETURNS_SMART_NULLS)
-    Mockito.when(mockS3Client.getBucketLifecycleConfiguration(org.mockito.Matchers.any()))
-      .thenReturn(new BucketLifecycleConfiguration().withRules(
+    when(mockS3Client.getBucketLifecycleConfiguration(any())).thenReturn(
+      new BucketLifecycleConfiguration().withRules(
         new Rule().withPrefix("").withStatus(BucketLifecycleConfiguration.ENABLED)
       ))
   }
@@ -124,59 +119,13 @@ class RedshiftSourceSuite
     super.afterEach()
     testSqlContext = null
     expectedDataDF = null
+    mockS3Client = null
     FileSystem.closeAll()
   }
 
   override def afterAll(): Unit = {
     sc.stop()
     super.afterAll()
-  }
-
-  /**
-   * Set up a mocked JDBCWrapper instance that expects a sequence of queries matching the given
-   * regular expressions will be executed, and that the connection returned will be closed.
-   */
-  private def mockJdbcWrapper(expectedUrl: String, expectedQueries: Seq[Regex]): JDBCWrapper = {
-    val jdbcWrapper = mock[JDBCWrapper]
-    val mockedConnection = mock[Connection]
-
-    (jdbcWrapper.getConnector _).expects(*, expectedUrl).returning(mockedConnection)
-
-    inSequence {
-      expectedQueries foreach { r =>
-        val mockedStatement = mock[PreparedStatement]
-        (mockedConnection.prepareStatement(_: String))
-          .expects(where {(sql: String) => r.findFirstMatchIn(sql).nonEmpty})
-          .returning(mockedStatement)
-        (mockedStatement.execute _).expects().returning(true)
-      }
-
-      (mockedConnection.close _).expects()
-    }
-
-    jdbcWrapper
-  }
-
-  /**
-   * Prepare the JDBC wrapper for an UNLOAD test.
-   */
-  private def prepareUnloadTest(
-      params: Map[String, String],
-      expectedQueries: Seq[Regex]): JDBCWrapper = {
-    val jdbcUrl = params("url")
-    val jdbcWrapper = mockJdbcWrapper(jdbcUrl, expectedQueries)
-
-    // We expect some extra calls to the JDBC wrapper,
-    // to register the driver and retrieve the schema.
-    (jdbcWrapper.registerDriver _)
-      .expects(*)
-      .anyNumberOfTimes()
-    (jdbcWrapper.resolveTable _)
-      .expects(jdbcUrl, "test_table")
-      .returning(TestUtils.testSchema)
-      .anyNumberOfTimes()
-
-    jdbcWrapper
   }
 
   test("DefaultSource can load Redshift UNLOAD output to a DataFrame") {
@@ -188,13 +137,16 @@ class RedshiftSourceSuite
       "TO '.*' " +
       "WITH CREDENTIALS 'aws_access_key_id=test1;aws_secret_access_key=test2' " +
       "ESCAPE").r
-    val jdbcWrapper = prepareUnloadTest(defaultParams, Seq(expectedQuery))
+    val mockRedshift =
+      new MockRedshift(defaultParams("url"), Map("test_table" -> TestUtils.testSchema))
 
     // Assert that we've loaded and converted all data in the test file
-    val source = new DefaultSource(jdbcWrapper, _ => mockS3Client)
+    val source = new DefaultSource(mockRedshift.jdbcWrapper, _ => mockS3Client)
     val relation = source.createRelation(testSqlContext, defaultParams)
     val df = testSqlContext.baseRelationToDataFrame(relation)
     checkAnswer(df, TestUtils.expectedData)
+    mockRedshift.verifyThatConnectionsWereClosed()
+    mockRedshift.verifyThatExpectedQueriesWereIssued(Seq(expectedQuery))
   }
 
   test("Can load output of Redshift queries") {
@@ -215,35 +167,24 @@ class RedshiftSourceSuite
     // Test with dbtable parameter that wraps the query in parens:
     {
       val params = defaultParams + ("dbtable" -> s"($query)")
-      val jdbcWrapper = mockJdbcWrapper(params("url"), Seq(expectedJDBCQuery))
-      (jdbcWrapper.registerDriver _)
-        .expects(*)
-        .anyNumberOfTimes()
-      (jdbcWrapper.resolveTable _)
-        .expects(params("url"), *)
-        .returning(querySchema)
-        .anyNumberOfTimes()
-      // Note: Assertions covered by mocks
-      val relation =
-        new DefaultSource(jdbcWrapper, _ => mockS3Client).createRelation(testSqlContext, params)
+      val mockRedshift =
+        new MockRedshift(defaultParams("url"), Map(params("dbtable") -> querySchema))
+      val relation = new DefaultSource(
+        mockRedshift.jdbcWrapper, _ => mockS3Client).createRelation(testSqlContext, params)
       testSqlContext.baseRelationToDataFrame(relation).collect()
+      mockRedshift.verifyThatConnectionsWereClosed()
+      mockRedshift.verifyThatExpectedQueriesWereIssued(Seq(expectedJDBCQuery))
     }
 
     // Test with query parameter
     {
       val params = defaultParams - "dbtable" + ("query" -> query)
-      val jdbcWrapper = mockJdbcWrapper(params("url"), Seq(expectedJDBCQuery))
-      (jdbcWrapper.registerDriver _)
-        .expects(*)
-        .anyNumberOfTimes()
-      (jdbcWrapper.resolveTable _)
-        .expects(params("url"), *)
-        .returning(querySchema)
-        .anyNumberOfTimes()
-      // Note: Assertions covered by mocks
-      val relation =
-        new DefaultSource(jdbcWrapper, _ => mockS3Client).createRelation(testSqlContext, params)
+      val mockRedshift = new MockRedshift(defaultParams("url"), Map(s"($query)" -> querySchema))
+      val relation = new DefaultSource(
+        mockRedshift.jdbcWrapper, _ => mockS3Client).createRelation(testSqlContext, params)
       testSqlContext.baseRelationToDataFrame(relation).collect()
+      mockRedshift.verifyThatConnectionsWereClosed()
+      mockRedshift.verifyThatExpectedQueriesWereIssued(Seq(expectedJDBCQuery))
     }
   }
 
@@ -253,9 +194,10 @@ class RedshiftSourceSuite
       "TO '.*' " +
       "WITH CREDENTIALS 'aws_access_key_id=test1;aws_secret_access_key=test2' " +
       "ESCAPE").r
-    val jdbcWrapper = prepareUnloadTest(defaultParams, Seq(expectedQuery))
+    val mockRedshift =
+      new MockRedshift(defaultParams("url"), Map("test_table" -> TestUtils.testSchema))
     // Construct the source with a custom schema
-    val source = new DefaultSource(jdbcWrapper, _ => mockS3Client)
+    val source = new DefaultSource(mockRedshift.jdbcWrapper, _ => mockS3Client)
     val relation = source.createRelation(testSqlContext, defaultParams, TestUtils.testSchema)
 
     val rdd = relation.asInstanceOf[PrunedFilteredScan]
@@ -267,6 +209,8 @@ class RedshiftSourceSuite
       Row(0.toByte, false),
       Row(null, null))
     assert(rdd.collect() === prunedExpectedValues)
+    mockRedshift.verifyThatConnectionsWereClosed()
+    mockRedshift.verifyThatExpectedQueriesWereIssued(Seq(expectedQuery))
   }
 
   test("DefaultSource supports user schema, pruned and filtered scans") {
@@ -284,10 +228,11 @@ class RedshiftSourceSuite
       "WITH CREDENTIALS 'aws_access_key_id=test1;aws_secret_access_key=test2' " +
       "ESCAPE").r
     // scalastyle:on
-    val jdbcWrapper = prepareUnloadTest(defaultParams, Seq(expectedQuery))
+    val mockRedshift =
+      new MockRedshift(defaultParams("url"), Map("test_table" -> TestUtils.testSchema))
 
     // Construct the source with a custom schema
-    val source = new DefaultSource(jdbcWrapper, _ => mockS3Client)
+    val source = new DefaultSource(mockRedshift.jdbcWrapper, _ => mockS3Client)
     val relation = source.createRelation(testSqlContext, defaultParams, TestUtils.testSchema)
 
     // Define a simple filter to only include a subset of rows
@@ -306,6 +251,8 @@ class RedshiftSourceSuite
     // Technically this assertion should check that the RDD only returns a single row, but
     // since we've mocked out Redshift our WHERE clause won't have had any effect.
     assert(rdd.collect().contains(Row(1, true)))
+    mockRedshift.verifyThatConnectionsWereClosed()
+    mockRedshift.verifyThatExpectedQueriesWereIssued(Seq(expectedQuery))
   }
 
   test("DefaultSource serializes data as Avro, then sends Redshift COPY command") {
@@ -328,21 +275,15 @@ class RedshiftSourceSuite
       """.stripMargin.trim.r,
       "DROP TABLE IF EXISTS test_table_staging_.*".r)
 
-    val jdbcWrapper = mockJdbcWrapper(params("url"), expectedCommands)
-
-    (jdbcWrapper.tableExists _)
-      .expects(*, "test_table")
-      .returning(true)
-      .anyNumberOfTimes()
-
-    (jdbcWrapper.schemaString _)
-      .expects(*)
-      .returning("schema")
-      .anyNumberOfTimes()
+    val mockRedshift =
+      new MockRedshift(defaultParams("url"), Map("test_table" -> TestUtils.testSchema))
 
     val relation = RedshiftRelation(
-      jdbcWrapper, _ => mockS3Client, Parameters.mergeParameters(params), None)(testSqlContext)
-    relation.asInstanceOf[InsertableRelation].insert(expectedDataDF, true)
+      mockRedshift.jdbcWrapper,
+      _ => mockS3Client,
+      Parameters.mergeParameters(params),
+      userSchema = None)(testSqlContext)
+    relation.asInstanceOf[InsertableRelation].insert(expectedDataDF, overwrite = true)
 
     // Make sure we wrote the data out ready for Redshift load, in the expected formats.
     // The data should have been written to a random subdirectory of `tempdir`. Since we clear
@@ -351,86 +292,50 @@ class RedshiftSourceSuite
     val dirWithAvroFiles = s3FileSystem.listStatus(new Path(s3TempDir)).head.getPath.toUri.toString
     val written = testSqlContext.read.format("com.databricks.spark.avro").load(dirWithAvroFiles)
     checkAnswer(written, TestUtils.expectedDataWithConvertedTimesAndDates)
+    mockRedshift.verifyThatConnectionsWereClosed()
+    mockRedshift.verifyThatExpectedQueriesWereIssued(expectedCommands)
   }
 
   test("Cannot write table with column names that become ambiguous under case insensitivity") {
-    val jdbcWrapper = mock[JDBCWrapper]
-    val mockedConnection = mock[Connection]
-    (jdbcWrapper.getConnector _)
-      .expects(*, defaultParams("url"))
-      .returning(mockedConnection)
-    (mockedConnection.close _).expects()
+    val mockRedshift =
+      new MockRedshift(defaultParams("url"), Map("test_table" -> TestUtils.testSchema))
 
     val schema = StructType(Seq(StructField("a", IntegerType), StructField("A", IntegerType)))
     val df = testSqlContext.createDataFrame(sc.emptyRDD[Row], schema)
-    val writer = new RedshiftWriter(jdbcWrapper, _ => mockS3Client)
+    val writer = new RedshiftWriter(mockRedshift.jdbcWrapper, _ => mockS3Client)
 
     intercept[IllegalArgumentException] {
       writer.saveToRedshift(
         testSqlContext, df, SaveMode.Append, Parameters.mergeParameters(defaultParams))
     }
+    mockRedshift.verifyThatConnectionsWereClosed()
+    mockRedshift.verifyThatExpectedQueriesWereIssued(Seq.empty)
   }
 
   test("Failed copies are handled gracefully when using a staging table") {
     val params = defaultParams ++ Map("usestagingtable" -> "true")
 
-    val jdbcWrapper = mock[JDBCWrapper]
-    val mockedConnection = mock[Connection]
+    val mockRedshift = new MockRedshift(
+      defaultParams("url"),
+      Map("test_table" -> TestUtils.testSchema),
+      jdbcQueriesThatShouldFail = Seq("COPY test_table_staging_.*".r))
 
-    (jdbcWrapper.getConnector _)
-      .expects(*, params("url"))
-      .returning(mockedConnection)
+    val expectedCommands = Seq(
+      "DROP TABLE IF EXISTS test_table_staging_.*".r,
+      "CREATE TABLE IF NOT EXISTS test_table_staging.*".r,
+      "COPY test_table_staging_.*".r,
+      ".*FROM stl_load_errors.*".r,
+      "DROP TABLE IF EXISTS test_table_staging.*".r
+    )
 
-    def successfulStatement(pattern: Regex): PreparedStatement = {
-      val mockedStatement = mock[PreparedStatement]
-      (mockedConnection.prepareStatement(_: String))
-        .expects(where {(sql: String) => pattern.findFirstMatchIn(sql).nonEmpty})
-        .returning(mockedStatement)
-      (mockedStatement.execute _).expects().returning(true)
-
-      mockedStatement
-    }
-
-    def failedStatement(pattern: Regex) : PreparedStatement = {
-      val mockedStatement = mock[PreparedStatement]
-      (mockedConnection.prepareStatement(_: String))
-        .expects(where {(sql: String) => pattern.findFirstMatchIn(sql).nonEmpty})
-        .returning(mockedStatement)
-
-      (mockedStatement.execute _)
-        .expects()
-        .throwing(new SQLException("Mocked Error"))
-
-      mockedStatement
-    }
-
-    (jdbcWrapper.tableExists _)
-      .expects(*, "test_table")
-      .returning(true)
-      .anyNumberOfTimes()
-
-    (jdbcWrapper.schemaString _)
-      .expects(*)
-      .anyNumberOfTimes()
-
-    inSequence {
-      // Initial staging table setup succeeds
-      successfulStatement("DROP TABLE IF EXISTS test_table_staging_.*".r)
-      successfulStatement("CREATE TABLE IF NOT EXISTS test_table_staging.*".r)
-
-      // Simulate COPY failure
-      failedStatement("COPY test_table_staging_.*".r)
-
-      // Expect recovery operations
-      successfulStatement("DROP TABLE IF EXISTS test_table_staging.*".r)
-
-      (mockedConnection.close _).expects()
-    }
-
-    val source = new DefaultSource(jdbcWrapper, _ => mockS3Client)
+    val source = new DefaultSource(mockRedshift.jdbcWrapper, _ => mockS3Client)
     intercept[Exception] {
       source.createRelation(testSqlContext, SaveMode.Overwrite, params, expectedDataDF)
+      mockRedshift.verifyThatConnectionsWereClosed()
+      mockRedshift.verifyThatExpectedQueriesWereIssued(expectedCommands)
     }
+    mockRedshift.verifyThatConnectionsWereClosed()
+    mockRedshift.verifyThatExpectedQueriesWereIssued(expectedCommands)
   }
 
   test("Append SaveMode doesn't destroy existing data") {
@@ -438,19 +343,9 @@ class RedshiftSourceSuite
       Seq("CREATE TABLE IF NOT EXISTS test_table .*".r,
           "COPY test_table .*".r)
 
-    val jdbcWrapper = mockJdbcWrapper(defaultParams("url"), expectedCommands)
+    val mockRedshift = new MockRedshift(defaultParams("url"), Map(defaultParams("dbtable") -> null))
 
-    (jdbcWrapper.tableExists _)
-      .expects(*, "test_table")
-      .returning(true)
-      .anyNumberOfTimes()
-
-    (jdbcWrapper.schemaString _)
-      .expects(*)
-      .returning("schema")
-      .anyNumberOfTimes()
-
-    val source = new DefaultSource(jdbcWrapper, _ => mockS3Client)
+    val source = new DefaultSource(mockRedshift.jdbcWrapper, _ => mockS3Client)
     val savedDf =
       source.createRelation(testSqlContext, SaveMode.Append, defaultParams, expectedDataDF)
 
@@ -462,6 +357,8 @@ class RedshiftSourceSuite
     val dirWithAvroFiles = s3FileSystem.listStatus(new Path(s3TempDir)).head.getPath.toUri.toString
     val written = testSqlContext.read.format("com.databricks.spark.avro").load(dirWithAvroFiles)
     checkAnswer(written, TestUtils.expectedDataWithConvertedTimesAndDates)
+    mockRedshift.verifyThatConnectionsWereClosed()
+    mockRedshift.verifyThatExpectedQueriesWereIssued(expectedCommands)
   }
 
   test("configuring maxlength on string columns") {
@@ -482,29 +379,22 @@ class RedshiftSourceSuite
   }
 
   test("Respect SaveMode.ErrorIfExists when table exists") {
-    val errIfExistsWrapper = mockJdbcWrapper(defaultParams("url"), Seq.empty[Regex])
-
-    (errIfExistsWrapper.tableExists _)
-      .expects(*, "test_table")
-      .returning(true)
-
-    val errIfExistsSource = new DefaultSource(errIfExistsWrapper, _ => mockS3Client)
+    val mockRedshift = new MockRedshift(defaultParams("url"), Map(defaultParams("dbtable") -> null))
+    val errIfExistsSource = new DefaultSource(mockRedshift.jdbcWrapper, _ => mockS3Client)
     intercept[Exception] {
       errIfExistsSource.createRelation(
         testSqlContext, SaveMode.ErrorIfExists, defaultParams, expectedDataDF)
     }
+    mockRedshift.verifyThatConnectionsWereClosed()
+    mockRedshift.verifyThatExpectedQueriesWereIssued(Seq.empty)
   }
 
   test("Do nothing when table exists if SaveMode = Ignore") {
-    val ignoreWrapper = mockJdbcWrapper(defaultParams("url"), Seq.empty[Regex])
-
-    (ignoreWrapper.tableExists _)
-      .expects(*, "test_table")
-      .returning(true)
-
-    // Note: Assertions covered by mocks
-    val ignoreSource = new DefaultSource(ignoreWrapper, _ => mockS3Client)
+    val mockRedshift = new MockRedshift(defaultParams("url"), Map(defaultParams("dbtable") -> null))
+    val ignoreSource = new DefaultSource(mockRedshift.jdbcWrapper, _ => mockS3Client)
     ignoreSource.createRelation(testSqlContext, SaveMode.Ignore, defaultParams, expectedDataDF)
+    mockRedshift.verifyThatConnectionsWereClosed()
+    mockRedshift.verifyThatExpectedQueriesWereIssued(Seq.empty)
   }
 
   test("Cannot save when 'query' parameter is specified instead of 'dbtable'") {


### PR DESCRIPTION
This patch refactors RedshiftSourceSuite to remove the use of ScalaMock.

The motivation for this is the fact that our previous ScalaMock code became a bit of an impediment when trying to refactor codepaths which created and closed new JDBC connections.