### PR TITLE
Automatically use Redshift 4.0 or 4.1 JDBC driver, depending on which is installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,8 +239,8 @@ and use that as a temp location for this data.
  <tr>
     <td><tt>jdbcdriver</tt></td>
     <td>No</td>
-    <td><tt>com.amazon.redshift.jdbc4.Driver</tt></td>
-    <td>The class name of the JDBC driver to load before JDBC operations. Must be on classpath.</td>
+    <td>Determined by the JDBC URL's subprotocol</td>
+    <td>The class name of the JDBC driver to load before JDBC operations. This class must be on the classpath. In most cases, it should not be necessary to specify this option, as the appropriate driver classname should automatically be determined by the JDBC URL's subprotocol.</td>
  </tr>
  <tr>
     <td><tt>diststyle</tt></td>

--- a/src/it/scala/com/databricks/spark/redshift/IntegrationSuiteBase.scala
+++ b/src/it/scala/com/databricks/spark/redshift/IntegrationSuiteBase.scala
@@ -86,7 +86,7 @@ trait IntegrationSuiteBase
     sc.hadoopConfiguration.setBoolean("fs.s3n.impl.disable.cache", true)
     sc.hadoopConfiguration.set("fs.s3n.awsAccessKeyId", AWS_ACCESS_KEY_ID)
     sc.hadoopConfiguration.set("fs.s3n.awsSecretAccessKey", AWS_SECRET_ACCESS_KEY)
-    conn = DefaultJDBCWrapper.getConnector("com.amazon.redshift.jdbc4.Driver", jdbcUrl)
+    conn = DefaultJDBCWrapper.getConnector(None, jdbcUrl)
   }
 
   override def afterAll(): Unit = {

--- a/src/main/scala/com/databricks/spark/redshift/Parameters.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Parameters.scala
@@ -29,8 +29,8 @@ private[redshift] object Parameters {
     // * tempdir, dbtable and url have no default and they *must* be provided
     // * sortkeyspec has no default, but is optional
     // * distkey has no default, but is optional unless using diststyle KEY
+    // * jdbcdriver has no default, but is optional
 
-    "jdbcdriver" -> "com.amazon.redshift.jdbc4.Driver",
     "overwrite" -> "false",
     "diststyle" -> "EVEN",
     "usestagingtable" -> "true",
@@ -106,9 +106,9 @@ private[redshift] object Parameters {
 
     /**
      * The JDBC driver class name. This is used to make sure the driver is registered before
-     * connecting over JDBC. Default is "com.amazon.redshift.jdbc4.Driver"
+     * connecting over JDBC.
      */
-    def jdbcDriver: String = parameters("jdbcdriver")
+    def jdbcDriver: Option[String] = parameters.get("jdbcdriver")
 
     /**
      * If true, when writing, replace any existing data. When false, append to the table instead.

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftJDBCWrapper.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftJDBCWrapper.scala
@@ -38,23 +38,15 @@ private[redshift] class JDBCWrapper {
     // DriverRegistry.register() is one of the few pieces of private Spark functionality which
     // we need to rely on. This class was relocated in Spark 1.5.0, so we need to use reflection
     // in order to support both Spark 1.4.x and 1.5.x.
-    // TODO: once 1.5.0 snapshots are on Maven, update this to switch the class name based on
-    // SPARK_VERSION.
-    val classLoader =
-      Option(Thread.currentThread().getContextClassLoader).getOrElse(this.getClass.getClassLoader)
     if (SPARK_VERSION.startsWith("1.4")) {
       val className = "org.apache.spark.sql.jdbc.package$DriverRegistry$"
-      // scalastyle:off
-      val driverRegistryClass = Class.forName(className, true, classLoader)
-      // scalastyle:on
+      val driverRegistryClass = Utils.classForName(className)
       val registerMethod = driverRegistryClass.getDeclaredMethod("register", classOf[String])
       val companionObject = driverRegistryClass.getDeclaredField("MODULE$").get(null)
       registerMethod.invoke(companionObject, driverClass)
     } else { // Spark 1.5.0+
       val className = "org.apache.spark.sql.execution.datasources.jdbc.DriverRegistry"
-      // scalastyle:off
-      val driverRegistryClass = Class.forName(className, true, classLoader)
-      // scalastyle:on
+      val driverRegistryClass = Utils.classForName(className)
       val registerMethod = driverRegistryClass.getDeclaredMethod("register", classOf[String])
       registerMethod.invoke(null, driverClass)
     }

--- a/src/main/scala/com/databricks/spark/redshift/Utils.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Utils.scala
@@ -37,6 +37,14 @@ private[redshift] object Utils {
 
   private val log = LoggerFactory.getLogger(getClass)
 
+  def classForName(className: String): Class[_] = {
+    val classLoader =
+      Option(Thread.currentThread().getContextClassLoader).getOrElse(this.getClass.getClassLoader)
+    // scalastyle:off
+    Class.forName(className, true, classLoader)
+    // scalastyle:on
+  }
+
   /**
    * Joins prefix URL a to path suffix b, and appends a trailing /, in order to create
    * a temp directory path for S3.

--- a/src/test/scala/com/databricks/spark/redshift/MockRedshift.scala
+++ b/src/test/scala/com/databricks/spark/redshift/MockRedshift.scala
@@ -63,9 +63,10 @@ class MockRedshift(
     conn
   }
 
-  when(jdbcWrapper.getConnector(anyString(), same(jdbcUrl))).thenAnswer(new Answer[Connection] {
-    override def answer(invocation: InvocationOnMock): Connection = createMockConnection()
-  })
+  when(jdbcWrapper.getConnector(any[Option[String]](), same(jdbcUrl))).thenAnswer(
+    new Answer[Connection] {
+      override def answer(invocation: InvocationOnMock): Connection = createMockConnection()
+    })
 
   when(jdbcWrapper.tableExists(any[Connection], anyString())).thenAnswer(new Answer[Boolean] {
     override def answer(invocation: InvocationOnMock): Boolean = {
@@ -73,7 +74,7 @@ class MockRedshift(
     }
   })
 
-  when(jdbcWrapper.resolveTable(same(jdbcUrl), anyString())).thenAnswer(new Answer[StructType] {
+  when(jdbcWrapper.resolveTable(any[Connection], anyString())).thenAnswer(new Answer[StructType] {
     override def answer(invocation: InvocationOnMock): StructType = {
       existingTablesAndSchemas(invocation.getArguments()(1).asInstanceOf[String])
     }


### PR DESCRIPTION
This patch refactors the driver-loading code so that it automatically uses either the Redshift JDBC 4.0 or 4.1 drivers, depending on which is installed. I also added support for automatically supplying an appropriate default JDBC driver class name when the `postgres://` subprotocol is used.

I tested all of the error-handling corner-cases manually.

Fixes #83.