### PR TITLE
Fix Utils.joinURLs on Windows

### DIFF
--- a/src/main/scala/com/databricks/spark/redshift/Utils.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Utils.scala
@@ -16,7 +16,6 @@
 
 package com.databricks.spark.redshift
 
-import java.io.File
 import java.net.URI
 import java.util.UUID
 
@@ -50,9 +49,7 @@ private[redshift] object Utils {
    * a temp directory path for S3.
    */
   def joinUrls(a: String, b: String): String = {
-    val aUri = new URI(a)
-    val joinedPath = new File(aUri.getPath, b).toString
-    new URI(aUri.getScheme, aUri.getHost, joinedPath, null).toString + "/"
+    a.stripSuffix("/") + "/" + b.stripPrefix("/").stripSuffix("/") + "/"
   }
 
   /**

--- a/src/test/scala/com/databricks/spark/redshift/UtilsSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/UtilsSuite.scala
@@ -25,6 +25,10 @@ class UtilsSuite extends FunSuite with Matchers {
 
   test("joinUrls preserves protocol information") {
     Utils.joinUrls("s3n://foo/bar/", "/baz") shouldBe "s3n://foo/bar/baz/"
+    Utils.joinUrls("s3n://foo/bar/", "/baz/") shouldBe "s3n://foo/bar/baz/"
+    Utils.joinUrls("s3n://foo/bar/", "baz/") shouldBe "s3n://foo/bar/baz/"
+    Utils.joinUrls("s3n://foo/bar/", "baz") shouldBe "s3n://foo/bar/baz/"
+    Utils.joinUrls("s3n://foo/bar", "baz") shouldBe "s3n://foo/bar/baz/"
   }
 
   test("fixUrl produces Redshift-compatible equivalents") {


### PR DESCRIPTION
This PR fixes an issue where `spark-redshift` would not work properly on Windows because the `Utils.joinUrls` method implicitly used the platform-specific path separator via `File`.