### PR TITLE
Fix problems in mapping between Spark and Redshift types for short and float columns

### DIFF
--- a/src/it/scala/com/databricks/spark/redshift/RedshiftIntegrationSuite.scala
+++ b/src/it/scala/com/databricks/spark/redshift/RedshiftIntegrationSuite.scala
@@ -287,7 +287,10 @@ class RedshiftIntegrationSuite extends IntegrationSuiteBase {
         .option("dbtable", tableName)
         .option("tempdir", tempDir)
         .load()
-      assert(loadedDf.schema === TestUtils.testSchema)
+      // Redshift doesn't have a BYTE type, so these schemas won't match for that column:
+      assert(
+        loadedDf.schema.filterNot(_.name == "testbyte") ===
+        TestUtils.testSchema.filterNot(_.name == "testbyte"))
       checkAnswer(loadedDf, TestUtils.expectedData)
     } finally {
       conn.prepareStatement(s"drop table if exists $tableName").executeUpdate()

--- a/src/it/scala/com/databricks/spark/redshift/RedshiftIntegrationSuite.scala
+++ b/src/it/scala/com/databricks/spark/redshift/RedshiftIntegrationSuite.scala
@@ -287,6 +287,7 @@ class RedshiftIntegrationSuite extends IntegrationSuiteBase {
         .option("dbtable", tableName)
         .option("tempdir", tempDir)
         .load()
+      assert(loadedDf.schema === TestUtils.testSchema)
       checkAnswer(loadedDf, TestUtils.expectedData)
     } finally {
       conn.prepareStatement(s"drop table if exists $tableName").executeUpdate()

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftJDBCWrapper.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftJDBCWrapper.scala
@@ -152,7 +152,7 @@ private[redshift] class JDBCWrapper {
         case LongType => "BIGINT"
         case DoubleType => "DOUBLE PRECISION"
         case FloatType => "REAL"
-        case ShortType => "INTEGER"
+        case ShortType => "SMALLINT"
         case ByteType => "SMALLINT" // Redshift does not support the BYTE type.
         case BooleanType => "BOOLEAN"
         case StringType =>
@@ -193,7 +193,8 @@ private[redshift] class JDBCWrapper {
       precision: Int,
       scale: Int,
       signed: Boolean): DataType = {
-    // TODO: cleanup types which are irrelevant for Redshift.
+    // See https://docs.aws.amazon.com/redshift/latest/dg/r_Numeric_types201.html for a reference
+    // on Redshift's numeric types.
     val answer = sqlType match {
       // scalastyle:off
       case java.sql.Types.ARRAY         => null
@@ -225,10 +226,12 @@ private[redshift] class JDBCWrapper {
       case java.sql.Types.NUMERIC       => DecimalType(38, 18) // Spark 1.5.0 default
       case java.sql.Types.NVARCHAR      => StringType
       case java.sql.Types.OTHER         => null
-      case java.sql.Types.REAL          => DoubleType
+      // In Redshift, REAL is a 4-byte floating point number with 6 significant digits of precision.
+      case java.sql.Types.REAL          => FloatType
       case java.sql.Types.REF           => StringType
       case java.sql.Types.ROWID         => LongType
-      case java.sql.Types.SMALLINT      => IntegerType
+      // In Redshift, SMALLINT is a 2-byte signed integer.
+      case java.sql.Types.SMALLINT      => ShortType
       case java.sql.Types.SQLXML        => StringType
       case java.sql.Types.STRUCT        => StringType
       case java.sql.Types.TIME          => TimestampType


### PR DESCRIPTION
This patch fixes two data-type-related problems which occur in roundtrip saves and loads of float- and short-typed columns:
- When creating Redshift tables, Spark SQL's `ShortType` was mapped to Redshift's `INTEGER` type instead of `SMALLINT`. When reading Redshift tables back into DataFrames, `SMALLINT` was mapped to `IntegerType` instead of `ShortType`.
- When creating DataFrames from Redshift tables, `getCatalystType()` mapped Redshift's `REAL` into `DoubleType`, but it actually corresponds to `FloatType`.
