### PR TITLE
Use manifest to skip COPY of empty partitions when writing to Redshift

### DIFF
--- a/src/it/scala/com/databricks/spark/redshift/RedshiftIntegrationSuite.scala
+++ b/src/it/scala/com/databricks/spark/redshift/RedshiftIntegrationSuite.scala
@@ -311,31 +311,22 @@ class RedshiftIntegrationSuite extends IntegrationSuiteBase {
   }
 
   test("save with one empty partition (regression test for #96)") {
-    val tableName = s"save_with_one_empty_partition_$randomSuffix"
     val df = sqlContext.createDataFrame(sc.parallelize(Seq(Row(1)), 2),
-      StructType(StructField("table", IntegerType) :: Nil))
+      StructType(StructField("foo", IntegerType) :: Nil))
     assert(df.rdd.glom.collect() === Array(Array.empty[Row], Array(Row(1))))
-    try {
-      df.write
-        .format("com.databricks.spark.redshift")
-        .option("url", jdbcUrl)
-        .option("dbtable", tableName)
-        .option("tempdir", tempDir)
-        .mode(SaveMode.ErrorIfExists)
-        .save()
-      assert(DefaultJDBCWrapper.tableExists(conn, tableName))
-      val loadedDf = sqlContext.read
-        .format("com.databricks.spark.redshift")
-        .option("url", jdbcUrl)
-        .option("dbtable", tableName)
-        .option("tempdir", tempDir)
-        .load()
-      assert(loadedDf.schema === df.schema)
-      checkAnswer(loadedDf, Seq(Row(1)))
-    } finally {
-      conn.prepareStatement(s"drop table if exists $tableName").executeUpdate()
-      conn.commit()
-    }
+    testRoundtripSaveAndLoad(s"save_with_one_empty_partition_$randomSuffix", df)
+  }
+
+  test("save with all empty partitions (regression test for #96)") {
+    val df = sqlContext.createDataFrame(sc.parallelize(Seq.empty[Row], 2),
+      StructType(StructField("foo", IntegerType) :: Nil))
+    assert(df.rdd.glom.collect() === Array(Array.empty[Row], Array.empty[Row]))
+    testRoundtripSaveAndLoad(s"save_with_all_empty_partitions_$randomSuffix", df)
+    // Now try overwriting that table. Although the new table is empty, it should still overwrite
+    // the existing table.
+    val df2 = df.withColumnRenamed("foo", "bar")
+    testRoundtripSaveAndLoad(
+      s"save_with_all_empty_partitions_$randomSuffix", df2, saveMode = SaveMode.Overwrite)
   }
 
   test("multiple scans on same table") {

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
@@ -141,7 +141,8 @@ private[redshift] class RedshiftWriter(
       // See https://docs.aws.amazon.com/redshift/latest/dg/loading-data-files-using-manifest.html
       // for a full description of the manifest format.
       val manifestEntries = filesToLoad.map { filename =>
-        s"""{"url":"${Utils.fixS3Url(filename)}", "mandatory":true}"""
+        val url = Utils.fixS3Url(Utils.removeCredentialsFromURI(URI.create(filename)).toString)
+        s"""{"url":"$url", "mandatory":true}"""
       }
       val manifest = s"""{"entries": [${manifestEntries.mkString(",\n")}]}"""
       val fs = FileSystem.get(URI.create(tempDir), data.sqlContext.sparkContext.hadoopConfiguration)

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
@@ -159,7 +159,7 @@ private[redshift] class RedshiftWriter(
     val createTable = conn.prepareStatement(createStatement)
     createTable.execute()
 
-    manifestUrl.map { manifestUrl =>
+    manifestUrl.foreach { manifestUrl =>
       // Load the temporary data into the new file
       val copyStatement = copySql(data.sqlContext, params, creds, manifestUrl)
       val copyData = conn.prepareStatement(copyStatement)

--- a/src/main/scala/com/databricks/spark/redshift/Utils.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Utils.scala
@@ -60,6 +60,20 @@ private[redshift] object Utils {
   }
 
   /**
+   * Returns a copy of the given URI with the user credentials removed.
+   */
+  def removeCredentialsFromURI(uri: URI): URI = {
+    new URI(
+      uri.getScheme,
+      null, // no user info
+      uri.getHost,
+      uri.getPort,
+      uri.getPath,
+      uri.getQuery,
+      uri.getFragment)
+  }
+
+  /**
    * Creates a randomly named temp directory path for intermediate data
    */
   def makeTempPath(tempRoot: String): String = Utils.joinUrls(tempRoot, UUID.randomUUID().toString)

--- a/src/test/scala/com/databricks/spark/redshift/UtilsSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/UtilsSuite.scala
@@ -16,6 +16,8 @@
 
 package com.databricks.spark.redshift
 
+import java.net.URI
+
 import org.scalatest.{FunSuite, Matchers}
 
 /**
@@ -42,5 +44,15 @@ class UtilsSuite extends FunSuite with Matchers {
 
     Utils.makeTempPath(root) should (startWith (root) and endWith ("/")
       and not equal root and not equal firstTempPath)
+  }
+
+  test("removeCredentialsFromURI removes AWS access keys") {
+    def removeCreds(uri: String): String = {
+      Utils.removeCredentialsFromURI(URI.create(uri)).toString
+    }
+    assert(removeCreds("s3n://bucket/path/to/temp/dir") === "s3n://bucket/path/to/temp/dir")
+    assert(
+      removeCreds("s3n://ACCESSKEY:SECRETKEY@bucket/path/to/temp/dir") ===
+      "s3n://bucket/path/to/temp/dir")
   }
 }


### PR DESCRIPTION
This WIP patch fixes #96, an issue where Redshift's COPY command did not cope well with empty Avro partitions.

The fix implemented here is to use a [manifest](https://docs.aws.amazon.com/redshift/latest/dg/loading-data-files-using-manifest.html) to instruct Redshift to load only the non-empty partitions' Avro files.