### PR TITLE
Fix bug in overwrite when using schema-qualified table names

### DIFF
--- a/src/main/scala/com/databricks/spark/redshift/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/redshift/DefaultSource.scala
@@ -77,7 +77,7 @@ class DefaultSource(jdbcWrapper: JDBCWrapper, s3ClientFactory: AWSCredentials =>
     def tableExists: Boolean = {
       val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl)
       try {
-        jdbcWrapper.tableExists(conn, table)
+        jdbcWrapper.tableExists(conn, table.toString)
       } finally {
         conn.close()
       }

--- a/src/main/scala/com/databricks/spark/redshift/Parameters.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Parameters.scala
@@ -80,12 +80,26 @@ private[redshift] object Parameters {
     /**
      * The Redshift table to be used as the target when loading or writing data.
      */
-    def table: Option[TableName] = parameters.get("dbtable").map(TableName.parseFromEscaped)
+    def table: Option[TableName] = parameters.get("dbtable").flatMap { dbtable =>
+      // We technically allow queries to be passed using `dbtable` as long as they are wrapped
+      // in parentheses. Valid SQL identifiers may contain parentheses but cannot begin with them,
+      // so there is no ambiguity in ignoring subqeries here and leaving their handling up to
+      // the `query` function defined below.
+      if (dbtable.startsWith("(") && dbtable.endsWith(")")) {
+        None
+      } else {
+        Some(TableName.parseFromEscaped(dbtable))
+      }
+    }
 
     /**
      * The Redshift query to be used as the target when loading data.
      */
-    def query: Option[String] = parameters.get("query")
+    def query: Option[String] = parameters.get("query").orElse {
+      parameters.get("dbtable")
+        .filter(t => t.startsWith("(") && t.endsWith(")"))
+        .map(t => t.drop(1).dropRight(1))
+    }
 
     /**
      * A JDBC URL, of the format:

--- a/src/main/scala/com/databricks/spark/redshift/Parameters.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Parameters.scala
@@ -80,7 +80,7 @@ private[redshift] object Parameters {
     /**
      * The Redshift table to be used as the target when loading or writing data.
      */
-    def table: Option[TableName] = parameters.get("dbtable").flatMap { dbtable =>
+    def table: Option[TableName] = parameters.get("dbtable").map(_.trim).flatMap { dbtable =>
       // We technically allow queries to be passed using `dbtable` as long as they are wrapped
       // in parentheses. Valid SQL identifiers may contain parentheses but cannot begin with them,
       // so there is no ambiguity in ignoring subqeries here and leaving their handling up to
@@ -97,6 +97,7 @@ private[redshift] object Parameters {
      */
     def query: Option[String] = parameters.get("query").orElse {
       parameters.get("dbtable")
+        .map(_.trim)
         .filter(t => t.startsWith("(") && t.endsWith(")"))
         .map(t => t.drop(1).dropRight(1))
     }

--- a/src/main/scala/com/databricks/spark/redshift/Parameters.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Parameters.scala
@@ -80,7 +80,7 @@ private[redshift] object Parameters {
     /**
      * The Redshift table to be used as the target when loading or writing data.
      */
-    def table: Option[String] = parameters.get("dbtable")
+    def table: Option[TableName] = parameters.get("dbtable").map(TableName.parseFromEscaped)
 
     /**
      * The Redshift query to be used as the target when loading data.

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
@@ -51,7 +51,8 @@ private[redshift] case class RedshiftRelation(
 
   override lazy val schema: StructType = {
     userSchema.getOrElse {
-      val tableNameOrSubquery = params.query.map(q => s"($q)").orElse(params.table).get
+      val tableNameOrSubquery =
+        params.query.map(q => s"($q)").orElse(params.table.map(_.toString)).get
       val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl)
       try {
         jdbcWrapper.resolveTable(conn, tableNameOrSubquery)
@@ -136,7 +137,7 @@ private[redshift] case class RedshiftRelation(
       // Since the query passed to UNLOAD will be enclosed in single quotes, we need to escape
       // any single quotes that appear in the query itself
       val tableNameOrSubquery: String = {
-        val unescaped = params.query.map(q => s"($q)").orElse(params.table).get
+        val unescaped = params.query.map(q => s"($q)").orElse(params.table.map(_.toString)).get
         unescaped.replace("'", "\\'")
       }
       s"SELECT $columnList FROM $tableNameOrSubquery $whereClause"

--- a/src/main/scala/com/databricks/spark/redshift/TableName.scala
+++ b/src/main/scala/com/databricks/spark/redshift/TableName.scala
@@ -16,6 +16,8 @@
 
 package com.databricks.spark.redshift
 
+import scala.collection.mutable.ArrayBuffer
+
 /**
  * Wrapper class for representing the name of a Redshift table.
  */
@@ -36,10 +38,40 @@ private[redshift] object TableName {
       if (s.startsWith("\"") && s.endsWith("\"")) s.drop(1).dropRight(1) else s
     def unescapeQuotes(s: String) = s.replace("\"\"", "\"")
     def unescape(s: String) = unescapeQuotes(dropOuterQuotes(s))
-    str.split('.').toSeq match {
+    splitByDots(str) match {
       case Seq(tableName) => TableName("PUBLIC", unescape(tableName))
       case Seq(schemaName, tableName) => TableName(unescape(schemaName), unescape(tableName))
       case other => throw new IllegalArgumentException(s"Could not parse table name from '$str'")
     }
+  }
+
+  /**
+   * Split by dots (.) while obeying our identifier quoting rules in order to allow dots to appear
+   * inside of quoted identifiers.
+   */
+  private def splitByDots(str: String): Seq[String] = {
+    val parts: ArrayBuffer[String] = ArrayBuffer.empty
+    val sb = new StringBuilder
+    var inQuotes: Boolean = false
+    for (c <- str) c match {
+      case '"' =>
+        // Note that double quotes are escaped by pairs of double quotes (""), so we don't need
+        // any extra code to handle them; we'll be back in inQuotes=true after seeing the pair.
+        sb.append('"')
+        inQuotes = !inQuotes
+      case '.' =>
+        if (!inQuotes) {
+          parts.append(sb.toString())
+          sb.clear()
+        } else {
+          sb.append('.')
+        }
+      case other =>
+        sb.append(other)
+    }
+    if (sb.nonEmpty) {
+      parts.append(sb.toString())
+    }
+    parts
   }
 }

--- a/src/main/scala/com/databricks/spark/redshift/TableName.scala
+++ b/src/main/scala/com/databricks/spark/redshift/TableName.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015 Databricks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.databricks.spark.redshift
+
+/**
+ * Wrapper class for representing the name of a Redshift table.
+ */
+private[redshift] case class TableName(unescapedSchemaName: String, unescapedTableName: String) {
+  private def quote(str: String) = '"' + str.replace("\"", "\"\"") + '"'
+  def escapedSchemaName: String = quote(unescapedSchemaName)
+  def escapedTableName: String = quote(unescapedTableName)
+  override def toString: String = s"$escapedSchemaName.$escapedTableName"
+}
+
+private[redshift] object TableName {
+  /**
+   * Parses a table name which is assumed to have been escaped according to Redshift's rules for
+   * delimited identifiers.
+   */
+  def parseFromEscaped(str: String): TableName = {
+    def dropOuterQuotes(s: String) =
+      if (s.startsWith("\"") && s.endsWith("\"")) s.drop(1).dropRight(1) else s
+    def unescapeQuotes(s: String) = s.replace("\"\"", "\"")
+    def unescape(s: String) = unescapeQuotes(dropOuterQuotes(s))
+    str.split('.').toSeq match {
+      case Seq(tableName) => TableName("PUBLIC", unescape(tableName))
+      case Seq(schemaName, tableName) => TableName(unescape(schemaName), unescape(tableName))
+      case other => throw new IllegalArgumentException(s"Could not parse table name from '$str'")
+    }
+  }
+}

--- a/src/test/scala/com/databricks/spark/redshift/ParametersSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/ParametersSuite.scala
@@ -26,7 +26,7 @@ class ParametersSuite extends FunSuite with Matchers {
   test("Minimal valid parameter map is accepted") {
     val params = Map(
       "tempdir" -> "s3://foo/bar",
-      "dbtable" -> "test_table",
+      "dbtable" -> "test_schema.test_table",
       "url" -> "jdbc:redshift://foo/bar")
 
     val mergedParams = Parameters.mergeParameters(params)
@@ -34,7 +34,7 @@ class ParametersSuite extends FunSuite with Matchers {
     mergedParams.rootTempDir should startWith (params("tempdir"))
     mergedParams.createPerQueryTempDir() should startWith (params("tempdir"))
     mergedParams.jdbcUrl shouldBe params("url")
-    mergedParams.table shouldBe Some(params("dbtable"))
+    mergedParams.table shouldBe Some(TableName("test_schema", "test_table"))
 
     // Check that the defaults have been added
     Parameters.DEFAULT_PARAMETERS foreach {

--- a/src/test/scala/com/databricks/spark/redshift/TableNameSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/TableNameSuite.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 Databricks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.databricks.spark.redshift
+
+import org.scalatest.FunSuite
+
+class TableNameSuite extends FunSuite {
+  test("TableName.parseFromEscaped") {
+    assert(TableName.parseFromEscaped("foo.bar") === TableName("foo", "bar"))
+    assert(TableName.parseFromEscaped("foo") === TableName("PUBLIC", "foo"))
+    assert(TableName.parseFromEscaped("\"foo\"") === TableName("PUBLIC", "foo"))
+    assert(TableName.parseFromEscaped("\"\"\"foo\"\"\".bar") === TableName("\"foo\"", "bar"))
+  }
+
+  test("TableName.toString") {
+    assert(TableName("foo", "bar").toString === """"foo"."bar"""")
+    assert(TableName("PUBLIC", "bar").toString === """"PUBLIC"."bar"""")
+    assert(TableName("\"foo\"", "bar").toString === "\"\"\"foo\"\"\".\"bar\"")
+  }
+}

--- a/src/test/scala/com/databricks/spark/redshift/TableNameSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/TableNameSuite.scala
@@ -24,6 +24,9 @@ class TableNameSuite extends FunSuite {
     assert(TableName.parseFromEscaped("foo") === TableName("PUBLIC", "foo"))
     assert(TableName.parseFromEscaped("\"foo\"") === TableName("PUBLIC", "foo"))
     assert(TableName.parseFromEscaped("\"\"\"foo\"\"\".bar") === TableName("\"foo\"", "bar"))
+    // Dots (.) can also appear inside of valid identifiers.
+    assert(TableName.parseFromEscaped("\"foo.bar\".baz") === TableName("foo.bar", "baz"))
+    assert(TableName.parseFromEscaped("\"foo\"\".bar\".baz") === TableName("foo\".bar", "baz"))
   }
 
   test("TableName.toString") {


### PR DESCRIPTION
This patch fixes #97, an issue where using `SaveMode.Overwrite` with schema-qualified table names (such as `my_schema.my_table`) would lead to "Invalid operation: syntax error at or near ".";" messages from Redshift.

The problem is that the `ALTER TABLE ... RENAME` command only accepts unqualified table names as the new names, so we need to strip off the schema prior to performing the renaming.

In order to keep this code clean, this patch introduces a new `TableName` case class which manages all of the escaping and parsing logic for table names, then uses that class to fix the Overwrite issue.