### PR TITLE
Update AWS Java SDK to 1.10.22

### DIFF
--- a/project/SparkRedshiftBuild.scala
+++ b/project/SparkRedshiftBuild.scala
@@ -64,9 +64,10 @@ object SparkRedshiftBuild extends Build {
         // There's a trade-off here and we've chosen to err on the side of minimizing dependency
         // conflicts for a majority of users while adding a minor inconvienece (adding one extra
         // depenendecy by hand) for a smaller set of users.
-        "com.amazonaws" % "aws-java-sdk-core" % "1.10.22" % "provided",
-        "com.amazonaws" % "aws-java-sdk-s3" % "1.10.22" % "provided",
-        "com.amazonaws" % "aws-java-sdk-sts" % "1.10.22" % "test",
+        // We exclude jackson-databind to avoid a conflict with Spark's version (see #104).
+        "com.amazonaws" % "aws-java-sdk-core" % "1.10.22" % "provided" exclude("com.fasterxml.jackson.core", "jackson-databind"),
+        "com.amazonaws" % "aws-java-sdk-s3" % "1.10.22" % "provided" exclude("com.fasterxml.jackson.core", "jackson-databind"),
+        "com.amazonaws" % "aws-java-sdk-sts" % "1.10.22" % "test" exclude("com.fasterxml.jackson.core", "jackson-databind"),
         // We require spark-avro, but avro-mapred must be provided to match Hadoop version.
         // In most cases, avro-mapred will be provided as part of the Spark assembly JAR.
         "com.databricks" %% "spark-avro" % "2.0.1",

--- a/project/SparkRedshiftBuild.scala
+++ b/project/SparkRedshiftBuild.scala
@@ -64,9 +64,9 @@ object SparkRedshiftBuild extends Build {
         // There's a trade-off here and we've chosen to err on the side of minimizing dependency
         // conflicts for a majority of users while adding a minor inconvienece (adding one extra
         // depenendecy by hand) for a smaller set of users.
-        "com.amazonaws" % "aws-java-sdk-core" % "1.9.40" % "provided",
-        "com.amazonaws" % "aws-java-sdk-s3" % "1.9.40" % "provided",
-        "com.amazonaws" % "aws-java-sdk-sts" % "1.9.40" % "test",
+        "com.amazonaws" % "aws-java-sdk-core" % "1.10.22" % "provided",
+        "com.amazonaws" % "aws-java-sdk-s3" % "1.10.22" % "provided",
+        "com.amazonaws" % "aws-java-sdk-sts" % "1.10.22" % "test",
         // We require spark-avro, but avro-mapred must be provided to match Hadoop version.
         // In most cases, avro-mapred will be provided as part of the Spark assembly JAR.
         "com.databricks" %% "spark-avro" % "2.0.1",

--- a/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
@@ -101,7 +101,7 @@ class RedshiftSourceSuite
     sc.hadoopConfiguration.set("fs.s3n.awsSecretAccessKey", "test2")
     // Configure a mock S3 client so that we don't hit errors when trying to access AWS in tests.
     mockS3Client = Mockito.mock(classOf[AmazonS3Client], Mockito.RETURNS_SMART_NULLS)
-    when(mockS3Client.getBucketLifecycleConfiguration(any())).thenReturn(
+    when(mockS3Client.getBucketLifecycleConfiguration(anyString())).thenReturn(
       new BucketLifecycleConfiguration().withRules(
         new Rule().withPrefix("").withStatus(BucketLifecycleConfiguration.ENABLED)
       ))


### PR DESCRIPTION
This upgrades the AWS Java SDK from 1.9.40 to 1.10.22. Although this version is only relevant in testing, I'm upgrading because older versions of the SDK have bugs in the `getBucketLifecycleConfiguration` configuration. According to an automated email from AWS:

> Your account has been identified as a user of the AWS SDK for Java making API requests to Amazon S3's getBucketLifecycleConfiguration operation. With the recent launch of the Standard – Infrequent Access storage class, getBucketLifecycleConfiguration's response can now have a new valid value for the StorageClass attribute: "STANDARD_IA".
>
> The AWS SDK for Java models this response element as an Enum, and STANDARD_IA was not a valid Enum value in previous versions of the SDK. Therefore, if a lifecycle policy involving the new storage class is configured on your bucket through other means such as the AWS Management Console, all getBucketLifecycleConfiguration calls made by previous versions of the AWS SDK for Java will fail with an AmazonClientException. If you plan to utilize Amazon S3's lifecycle feature with the new Standard - Infrequent Access storage class, it is critical that you update your AWS SDK for Java to 1.10.19 or later to avoid running into this error.

This upgrade should help other developers who test this library to avoid receiving the same message from Amazon.