### PR TITLE
Enable data source short name for Spark 1.5.0+

### DIFF
--- a/project/SparkRedshiftBuild.scala
+++ b/project/SparkRedshiftBuild.scala
@@ -43,7 +43,7 @@ object SparkRedshiftBuild extends Build {
       organization := "com.databricks",
       scalaVersion := "2.10.5",
       crossScalaVersions := Seq("2.10.5", "2.11.7"),
-      sparkVersion := "1.4.1",
+      sparkVersion := "1.5.0",
       testSparkVersion := sys.props.get("spark.testVersion").getOrElse(sparkVersion.value),
       testHadoopVersion := sys.props.get("hadoop.testVersion").getOrElse("2.2.0"),
       spName := "databricks/spark-redshift",

--- a/project/SparkRedshiftBuild.scala
+++ b/project/SparkRedshiftBuild.scala
@@ -43,7 +43,7 @@ object SparkRedshiftBuild extends Build {
       organization := "com.databricks",
       scalaVersion := "2.10.5",
       crossScalaVersions := Seq("2.10.5", "2.11.7"),
-      sparkVersion := "1.5.0",
+      sparkVersion := "1.4.1",
       testSparkVersion := sys.props.get("spark.testVersion").getOrElse(sparkVersion.value),
       testHadoopVersion := sys.props.get("hadoop.testVersion").getOrElse("2.2.0"),
       spName := "databricks/spark-redshift",

--- a/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -1,0 +1,1 @@
+com.databricks.spark.redshift.DefaultSource

--- a/src/main/scala/com/databricks/spark/redshift/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/redshift/DefaultSource.scala
@@ -18,7 +18,7 @@ package com.databricks.spark.redshift
 
 import com.amazonaws.auth.AWSCredentials
 import com.amazonaws.services.s3.AmazonS3Client
-import org.apache.spark.sql.sources.{BaseRelation, CreatableRelationProvider, RelationProvider, SchemaRelationProvider}
+import org.apache.spark.sql.sources.{BaseRelation, CreatableRelationProvider, DataSourceRegister, RelationProvider, SchemaRelationProvider}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode}
 import org.slf4j.LoggerFactory
@@ -29,9 +29,12 @@ import org.slf4j.LoggerFactory
 class DefaultSource(jdbcWrapper: JDBCWrapper, s3ClientFactory: AWSCredentials => AmazonS3Client)
   extends RelationProvider
   with SchemaRelationProvider
+  with DataSourceRegister
   with CreatableRelationProvider {
 
   private val log = LoggerFactory.getLogger(getClass)
+
+  override def shortName(): String = "redshift"
 
   /**
    * Default constructor required by Data Source API

--- a/src/main/scala/org/apache/spark/sql/sources/DataSourceRegister.scala
+++ b/src/main/scala/org/apache/spark/sql/sources/DataSourceRegister.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.sources
+
+import org.apache.spark.annotation.DeveloperApi
+
+// This file is a verbatim copy of the DataSourceRegister class from Spark. We need to ship a copy
+// of this class in `spark-redshift` in order for our build to maintain source- and
+// binary-compatibility with both Spark 1.4.x and 1.5.0+.
+
+/**
+ * ::DeveloperApi::
+ * Data sources should implement this trait so that they can register an alias to their data source.
+ * This allows users to give the data source alias as the format type over the fully qualified
+ * class name.
+ *
+ * A new instance of this class with be instantiated each time a DDL call is made.
+ *
+ * @since 1.5.0
+ */
+@DeveloperApi
+trait DataSourceRegister {
+
+  /**
+   * The string that represents the format that this data source provider uses. This is
+   * overridden by children to provide a nice alias for the data source. For example:
+   *
+   * {{{
+   *   override def shortName(): String = "parquet"
+   * }}}
+   *
+   * @since 1.5.0
+   */
+  def shortName(): String
+}

--- a/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
@@ -453,4 +453,15 @@ class RedshiftSourceSuite
     }
     assert(e.getMessage.contains("Block FileSystem"))
   }
+
+  test("DefaultSource supports shortName") {
+    assume(org.apache.spark.SPARK_VERSION.take(3) >= "1.5",
+      "Data source short names are only supported in Spark 1.5+")
+    val resolvedSource = {
+      Utils.classForName("org.apache.spark.sql.execution.datasources.ResolvedDataSource")
+        .getDeclaredMethod("lookupDataSource", classOf[String])
+        .invoke(null, "redshift")
+    }
+    assert(resolvedSource === classOf[DefaultSource])
+  }
 }


### PR DESCRIPTION
This patch allows `spark-redshift` to take advantage of the new support for data source short names / aliases added in Spark 1.5.0+ (https://github.com/apache/spark/pull/7802). This allows users to write

```
sqlContext.read.format("redshift")
```

instead of

```
sqlContext.read.format("com.databricks.spark.redshift")
```

The short name also works in other contexts, including SQL queries.

Unfortunately, this patch is made overly complicated by a binary compatibility issue: if a data source is compiled against Spark 1.5.0 and extends the new `DataSourceRegister` class, then it will hit ClassNotFoundExceptions when running against Spark 1.4.x. In order to work around this, I inlined a copy of the `DataSourceRegister` class into `spark-redshift` itself.

This compatibility issue also affected `spark-csv`: https://github.com/databricks/spark-csv/pull/160

/cc @pwendell, @marmbrus, @falaki, @jdrit