### PR TITLE
Fix thread-safety issues related to SimpleDateFormat and DecimalFormat

### DIFF
--- a/src/it/scala/com/databricks/spark/redshift/DecimalIntegrationSuite.scala
+++ b/src/it/scala/com/databricks/spark/redshift/DecimalIntegrationSuite.scala
@@ -27,8 +27,13 @@ class DecimalIntegrationSuite extends IntegrationSuiteBase {
   private def testReadingDecimals(precision: Int, scale: Int, decimalStrings: Seq[String]): Unit = {
     test(s"reading DECIMAL($precision, $scale)") {
       val tableName = s"reading_decimal_${precision}_${scale}_$randomSuffix"
-      val expectedRows =
-        decimalStrings.map(d => Row(if (d == null) null else Conversions.parseDecimal(d)))
+      val expectedRows = decimalStrings.map { d =>
+        if (d == null) {
+          Row(null)
+        } else {
+          Row(Conversions.createRedshiftDecimalFormat().parse(d).asInstanceOf[java.math.BigDecimal])
+        }
+      }
       try {
         conn.createStatement().executeUpdate(
           s"CREATE TABLE $tableName (x DECIMAL($precision, $scale))")

--- a/src/main/scala/com/databricks/spark/redshift/Conversions.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Conversions.scala
@@ -53,7 +53,7 @@ private[redshift] object Conversions {
    * This formatter should not be used when saving dates back to Redshift; instead, use
    * [[RedshiftTimestampFormat]].
    */
-  def createRedshiftDateFormat() = new SimpleDateFormat("yyyy-MM-dd")
+  def createRedshiftDateFormat(): SimpleDateFormat = new SimpleDateFormat("yyyy-MM-dd")
 
   /**
    * Return a function that will convert arrays of strings conforming to the given schema to Rows.

--- a/src/main/scala/com/databricks/spark/redshift/Conversions.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Conversions.scala
@@ -20,6 +20,8 @@ import java.sql.Timestamp
 import java.text.{DecimalFormat, DateFormat, FieldPosition, ParsePosition, SimpleDateFormat}
 import java.util.Date
 
+import scala.collection.mutable
+
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.Row
 
@@ -27,60 +29,6 @@ import org.apache.spark.sql.Row
  * Data type conversions for Redshift unloaded data
  */
 private[redshift] object Conversions {
-
-  // Redshift may or may not include the fraction component in the UNLOAD data, and there are
-  // apparently not clues about this in the table schema. This format delegates to one of the above
-  // formats based on string length.
-  private val redshiftTimestampFormat: DateFormat = new DateFormat() {
-
-    // Imports and exports with Redshift require that timestamps are represented
-    // as strings, using the following formats
-    private val PATTERN_WITH_MILLIS = "yyyy-MM-dd HH:mm:ss.SSS"
-    private val PATTERN_WITHOUT_MILLIS = "yyyy-MM-dd HH:mm:ss"
-
-    private val redshiftTimestampFormatWithMillis = new SimpleDateFormat(PATTERN_WITH_MILLIS)
-    private val redshiftTimestampFormatWithoutMillis = new SimpleDateFormat(PATTERN_WITHOUT_MILLIS)
-
-    override def format(
-        date: Date,
-        toAppendTo: StringBuffer,
-        fieldPosition: FieldPosition): StringBuffer = {
-      // Always export with milliseconds, as they can just be zero if not specified
-      redshiftTimestampFormatWithMillis.format(date, toAppendTo, fieldPosition)
-    }
-
-    override def parse(source: String, pos: ParsePosition): Date = {
-      if (source.length < PATTERN_WITH_MILLIS.length) {
-        redshiftTimestampFormatWithoutMillis.parse(source, pos)
-      } else {
-        redshiftTimestampFormatWithMillis.parse(source, pos)
-      }
-    }
-  }
-
-  private val redshiftDateFormat = new SimpleDateFormat("yyyy-MM-dd")
-
-  /**
-   * Parse a string exported from a Redshift TIMESTAMP column
-   */
-  private def parseTimestamp(s: String): Timestamp = {
-    new Timestamp(redshiftTimestampFormat.parse(s).getTime)
-  }
-
-  /**
-   * Parse a string exported from a Redshift DATE column
-   */
-  private def parseDate(s: String): java.sql.Date = {
-    new java.sql.Date(redshiftDateFormat.parse(s).getTime)
-  }
-
-  def formatDate(d: Date): String = {
-    redshiftTimestampFormat.format(d)
-  }
-
-  def formatTimestamp(t: Timestamp): String = {
-    redshiftTimestampFormat.format(t)
-  }
 
   /**
    * Parse a boolean using Redshift's UNLOAD bool syntax
@@ -91,47 +39,96 @@ private[redshift] object Conversions {
     else throw new IllegalArgumentException(s"Expected 't' or 'f' but got '$s'")
   }
 
-  private[this] val redshiftDecimalFormat: DecimalFormat = new DecimalFormat()
-  redshiftDecimalFormat.setParseBigDecimal(true)
-
   /**
-   * Parse a decimal using Redshift's UNLOAD decimal syntax
+   * Formatter for writing decimals unloaded from Redshift.
    */
-  def parseDecimal(s: String): java.math.BigDecimal = {
-    redshiftDecimalFormat.parse(s).asInstanceOf[java.math.BigDecimal]
-  }
-  /**
-   * Construct a Row from the given array of strings, retrieved from Redshift UNLOAD.
-   * The schema will be used for type mappings.
-   */
-  private def convertRow(schema: StructType, fields: Array[String]): Row = {
-    val converted = fields.zip(schema).map {
-      case (data, field) =>
-        if (data == null || data.isEmpty) null
-        else field.dataType match {
-          case ByteType => data.toByte
-          case BooleanType => parseBoolean(data)
-          case DateType => parseDate(data)
-          case DoubleType => data.toDouble
-          case FloatType => data.toFloat
-          case dt: DecimalType => parseDecimal(data)
-          case IntegerType => data.toInt
-          case LongType => data.toLong
-          case ShortType => data.toShort
-          case StringType => data
-          case TimestampType => parseTimestamp(data)
-          case _ => data
-        }
-    }
-
-    Row.fromSeq(converted)
+  def createRedshiftDecimalFormat(): DecimalFormat = {
+    val format = new DecimalFormat()
+    format.setParseBigDecimal(true)
+    format
   }
 
   /**
-   * Return a function that will convert arrays of strings conforming to
-   * the given schema to Row instances
+   * Formatter for parsing strings exported from Redshift DATE columns.
+   * This formatter should not be used when saving dates back to Redshift; instead, use
+   * [[RedshiftTimestampFormat]].
+   */
+  def createRedshiftDateFormat() = new SimpleDateFormat("yyyy-MM-dd")
+
+  /**
+   * Return a function that will convert arrays of strings conforming to the given schema to Rows.
+   *
+   * Note that instances of this function are NOT thread-safe.
    */
   def createRowConverter(schema: StructType): (Array[String]) => Row = {
-    convertRow(schema, _: Array[String])
+    val timestampFormat = new RedshiftTimestampFormat
+    val dateFormat = createRedshiftDateFormat()
+    val decimalFormat = createRedshiftDecimalFormat()
+    val conversionFunctions: Array[String => Any] = schema.fields.map { field =>
+      field.dataType match {
+        case ByteType => (data: String) => data.toByte
+        case BooleanType => (data: String) => parseBoolean(data)
+        case DateType => (data: String) => new java.sql.Date(dateFormat.parse(data).getTime)
+        case DoubleType => (data: String) => data.toDouble
+        case FloatType => (data: String) => data.toFloat
+        case dt: DecimalType =>
+          (data: String) => decimalFormat.parse(data).asInstanceOf[java.math.BigDecimal]
+        case IntegerType => (data: String) => data.toInt
+        case LongType => (data: String) => data.toLong
+        case ShortType => (data: String) => data.toShort
+        case StringType => (data: String) => data
+        case TimestampType => (data: String) => new Timestamp(timestampFormat.parse(data).getTime)
+        case _ => (data: String) => data
+      }
+    }
+    // As a performance optimization, re-use the same mutable Seq:
+    val converted: mutable.IndexedSeq[Any] = mutable.IndexedSeq.fill(schema.length)(null)
+    (fields: Array[String]) => {
+      var i = 0
+      while (i < schema.length) {
+        val data = fields(i)
+        converted(i) = if (data == null || data.isEmpty) null else conversionFunctions(i)(data)
+        i += 1
+      }
+      Row.fromSeq(converted)
+    }
+  }
+}
+
+/**
+ * Formatter for parsing strings exported from Redshift TIMESTAMP columns and for formatting
+ * timestamps as strings when writing data back to Redshift via Avro.
+ *
+ * Redshift may or may not include the fraction component in the UNLOAD data, and there are
+ * apparently not clues about this in the table schema. This format delegates to one of two
+ * formats based on string length.
+ *
+ * Instances of this class are NOT thread-safe (because they rely on Java's DateFormat classes,
+ * which are also not thread-safe).
+ */
+private[redshift] class RedshiftTimestampFormat extends DateFormat {
+
+  // Imports and exports with Redshift require that timestamps are represented
+  // as strings, using the following formats
+  private val PATTERN_WITH_MILLIS = "yyyy-MM-dd HH:mm:ss.SSS"
+  private val PATTERN_WITHOUT_MILLIS = "yyyy-MM-dd HH:mm:ss"
+
+  private val redshiftTimestampFormatWithMillis = new SimpleDateFormat(PATTERN_WITH_MILLIS)
+  private val redshiftTimestampFormatWithoutMillis = new SimpleDateFormat(PATTERN_WITHOUT_MILLIS)
+
+  override def format(
+      date: Date,
+      toAppendTo: StringBuffer,
+      fieldPosition: FieldPosition): StringBuffer = {
+    // Always export with milliseconds, as they can just be zero if not specified
+    redshiftTimestampFormatWithMillis.format(date, toAppendTo, fieldPosition)
+  }
+
+  override def parse(source: String, pos: ParsePosition): Date = {
+    if (source.length < PATTERN_WITH_MILLIS.length) {
+      redshiftTimestampFormatWithoutMillis.parse(source, pos)
+    } else {
+      redshiftTimestampFormatWithMillis.parse(source, pos)
+    }
   }
 }

--- a/src/main/scala/com/databricks/spark/redshift/Conversions.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Conversions.scala
@@ -41,6 +41,9 @@ private[redshift] object Conversions {
 
   /**
    * Formatter for writing decimals unloaded from Redshift.
+   *
+   * Note that Java Formatters are NOT thread-safe, so you should not re-use instances of this
+   * DecimalFormat across threads.
    */
   def createRedshiftDecimalFormat(): DecimalFormat = {
     val format = new DecimalFormat()
@@ -52,6 +55,9 @@ private[redshift] object Conversions {
    * Formatter for parsing strings exported from Redshift DATE columns.
    * This formatter should not be used when saving dates back to Redshift; instead, use
    * [[RedshiftTimestampFormat]].
+   *
+   * Note that Java Formatters are NOT thread-safe, so you should not re-use instances of this
+   * SimpleDateFormat across threads.
    */
   def createRedshiftDateFormat(): SimpleDateFormat = new SimpleDateFormat("yyyy-MM-dd")
 

--- a/src/test/scala/com/databricks/spark/redshift/TestUtils.scala
+++ b/src/test/scala/com/databricks/spark/redshift/TestUtils.scala
@@ -68,8 +68,8 @@ object TestUtils {
    */
   val expectedDataWithConvertedTimesAndDates: Seq[Row] = expectedData.map { row =>
     Row.fromSeq(row.toSeq.map {
-      case t: Timestamp => Conversions.formatTimestamp(t)
-      case d: Date => Conversions.formatDate(d)
+      case t: Timestamp => new RedshiftTimestampFormat().format(t)
+      case d: Date => new RedshiftTimestampFormat().format(d)
       case other => other
     })
   }


### PR DESCRIPTION
Java's SimpleDateFormat and DecimalFormat classes are not thread-safe, which caused problems because `spark-redshift` was using global instances of these classes.

There are multiple possible strategies for fixing this. To work around the SimpleDateFormat issue, we could have switched to using Joda Time or `commons-lang`, both of which have thread-safe date formatters. However, I'm a bit wary of introducing another dependency, particularly one which might conflict with user libraries. In addition, switching the date/time library still won't solve the decimal format problem.

The approach implemented in this patch is to create new `*Format` instances in every task as part of creating converter functions. While working on this, I took the opportunity to perform a performance-related refactoring where the read-path conversion operates by looping over an array of functions rather than using a match statement inside of the loop. This idiom is used throughout Spark SQL's own internals (see CatalystTypeConverters). 

Fixes #107.