### PR TITLE
Add example of writing data back to Redshift using SQL API

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,13 +115,32 @@ df.write \
 
 #### SQL
 
+Reading data using SQL:
+
 ```sql
 CREATE TABLE my_table
 USING com.databricks.spark.redshift
-OPTIONS (dbtable 'my_table',
-         tempdir 's3n://my_bucket/tmp',
-         url 'jdbc:redshift://host:port/db?user=username&password=pass');
+OPTIONS (
+  dbtable 'my_table',
+  tempdir 's3n://my_bucket/tmp',
+  url 'jdbc:redshift://host:port/db?user=username&password=pass'
+);
 ```
+
+Writing data using SQL:
+
+```sql
+CREATE TABLE my_table
+USING com.databricks.spark.redshift
+OPTIONS (
+  dbtable 'my_table',
+  tempdir 's3n://my_bucket/tmp'
+  url 'jdbc:redshift://host:port/db?user=username&password=pass'
+)
+AS SELECT * FROM tabletosave;
+```
+
+Note that the SQL API only supports the creation of new tables and not overwriting or appending; this corresponds to the default save mode of the other language APIs.
 
 ### Hadoop InputFormat
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ OPTIONS (
 Writing data using SQL:
 
 ```sql
--- Create a new table, throwing an error of a table with the same name already exists:
+-- Create a new table, throwing an error if a table with the same name already exists:
 CREATE TABLE my_table
 USING com.databricks.spark.redshift
 OPTIONS (

--- a/README.md
+++ b/README.md
@@ -122,20 +122,21 @@ CREATE TABLE my_table
 USING com.databricks.spark.redshift
 OPTIONS (
   dbtable 'my_table',
-  tempdir 's3n://my_bucket/tmp',
-  url 'jdbc:redshift://host:port/db?user=username&password=pass'
+  tempdir 's3n://path/for/temp/data',
+  url 'jdbc:redshift://redshifthost:5439/database?user=username&password=pass'
 );
 ```
 
 Writing data using SQL:
 
 ```sql
+-- Create a new table, throwing an error of a table with the same name already exists:
 CREATE TABLE my_table
 USING com.databricks.spark.redshift
 OPTIONS (
   dbtable 'my_table',
-  tempdir 's3n://my_bucket/tmp'
-  url 'jdbc:redshift://host:port/db?user=username&password=pass'
+  tempdir 's3n://path/for/temp/data'
+  url 'jdbc:redshift://redshifthost:5439/database?user=username&password=pass'
 )
 AS SELECT * FROM tabletosave;
 ```


### PR DESCRIPTION
This updates the README to include an example of saving data back to Redshift while using the SQL language API.

Fixes #81.