### PR TITLE
Fix Hadoop and Spark version configurations in integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,10 +45,6 @@ env:
     - secure: "LvndQIW6dHs6nyaMHtblGI/oL+s460lOezFs2BoD0Isenb/O/IM+nY5K9HepTXjJIcq8qvUYnojZX1FCrxxOXX2/+/Iihiq7GzJYdmdMC6hLg9bJYeAFk0dWYT88/AwadrJCBOa3ockRLhiO3dkai7Ki5+M1erfaFiAHHMpJxYQ="
 
 script:
-  - sbt -Dhadoop.testVersion=$HADOOP_VERSION -Dspark.testVersion=$SPARK_VERSION ++$TRAVIS_SCALA_VERSION coverage test
-  - if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then sbt -Dhadoop.version=$HADOOP_VERSION -Dspark.version=$SPARK_VERSION ++$TRAVIS_SCALA_VERSION coverage it:test 2> /dev/null; fi
-  - sbt ++$TRAVIS_SCALA_VERSION scalastyle
-  - sbt ++$TRAVIS_SCALA_VERSION "test:scalastyle"
-  - sbt ++$TRAVIS_SCALA_VERSION  "it:scalastyle"
+  - ./dev/run-tests-travis.sh
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/dev/run-tests-travis.sh
+++ b/dev/run-tests-travis.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -e
+
+sbt ++$TRAVIS_SCALA_VERSION scalastyle
+sbt ++$TRAVIS_SCALA_VERSION "test:scalastyle"
+sbt ++$TRAVIS_SCALA_VERSION "it:scalastyle"
+
+sbt \
+  -Dhadoop.testVersion=$HADOOP_VERSION \
+  -Dspark.testVersion=$SPARK_VERSION \
+  ++$TRAVIS_SCALA_VERSION \
+  coverage test
+
+if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then
+  sbt \
+    -Dhadoop.testVersion=$HADOOP_VERSION \
+    -Dspark.testVersion=$SPARK_VERSION \
+    ++$TRAVIS_SCALA_VERSION \
+    coverage it:test 2> /dev/null;
+fi

--- a/dev/run-tests-travis.sh
+++ b/dev/run-tests-travis.sh
@@ -17,6 +17,6 @@ if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then
     -Dhadoop.testVersion=$HADOOP_VERSION \
     -Dspark.testVersion=$SPARK_VERSION \
     ++$TRAVIS_SCALA_VERSION \
-    coverage "it:testOnly *RedshiftIntegration* -- -z \"roundtrip save and load\"" 2> /dev/null;
+    coverage "it:testOnly *RedshiftIntegration* -- -z \"roundtrip save and load\""
     # coverage it:test 2> /dev/null;
 fi

--- a/dev/run-tests-travis.sh
+++ b/dev/run-tests-travis.sh
@@ -2,21 +2,20 @@
 
 set -e
 
-#sbt ++$TRAVIS_SCALA_VERSION scalastyle
-#sbt ++$TRAVIS_SCALA_VERSION "test:scalastyle"
-#sbt ++$TRAVIS_SCALA_VERSION "it:scalastyle"
+sbt ++$TRAVIS_SCALA_VERSION scalastyle
+sbt ++$TRAVIS_SCALA_VERSION "test:scalastyle"
+sbt ++$TRAVIS_SCALA_VERSION "it:scalastyle"
 
-#sbt \
-  #-Dhadoop.testVersion=$HADOOP_VERSION \
-  #-Dspark.testVersion=$SPARK_VERSION \
-  #++$TRAVIS_SCALA_VERSION \
-  #coverage test
+sbt \
+  -Dhadoop.testVersion=$HADOOP_VERSION \
+  -Dspark.testVersion=$SPARK_VERSION \
+  ++$TRAVIS_SCALA_VERSION \
+  coverage test
 
 if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then
   sbt \
     -Dhadoop.testVersion=$HADOOP_VERSION \
     -Dspark.testVersion=$SPARK_VERSION \
     ++$TRAVIS_SCALA_VERSION \
-    coverage "it:testOnly *RedshiftIntegration* -- -z \"roundtrip save and load\""
-    # coverage it:test 2> /dev/null;
+    coverage it:test 2> /dev/null;
 fi

--- a/dev/run-tests-travis.sh
+++ b/dev/run-tests-travis.sh
@@ -2,20 +2,21 @@
 
 set -e
 
-sbt ++$TRAVIS_SCALA_VERSION scalastyle
-sbt ++$TRAVIS_SCALA_VERSION "test:scalastyle"
-sbt ++$TRAVIS_SCALA_VERSION "it:scalastyle"
+#sbt ++$TRAVIS_SCALA_VERSION scalastyle
+#sbt ++$TRAVIS_SCALA_VERSION "test:scalastyle"
+#sbt ++$TRAVIS_SCALA_VERSION "it:scalastyle"
 
-sbt \
-  -Dhadoop.testVersion=$HADOOP_VERSION \
-  -Dspark.testVersion=$SPARK_VERSION \
-  ++$TRAVIS_SCALA_VERSION \
-  coverage test
+#sbt \
+  #-Dhadoop.testVersion=$HADOOP_VERSION \
+  #-Dspark.testVersion=$SPARK_VERSION \
+  #++$TRAVIS_SCALA_VERSION \
+  #coverage test
 
 if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then
   sbt \
     -Dhadoop.testVersion=$HADOOP_VERSION \
     -Dspark.testVersion=$SPARK_VERSION \
     ++$TRAVIS_SCALA_VERSION \
-    coverage it:test 2> /dev/null;
+    coverage "it:testOnly *RedshiftIntegration* -- -z \"roundtrip save and load\"" 2> /dev/null;
+    # coverage it:test 2> /dev/null;
 fi

--- a/project/SparkRedshiftBuild.scala
+++ b/project/SparkRedshiftBuild.scala
@@ -113,6 +113,7 @@ object SparkRedshiftBuild extends Build {
           x => x.data.getName.contains("hadoop1") && x.data.getName.contains("avro")
         }
       }),
+      fullClasspath in IntegrationTest := (fullClasspath in Test).value,
       ScoverageSbtPlugin.ScoverageKeys.coverageHighlighting := {
         if (scalaBinaryVersion.value == "2.10") false
         else true

--- a/project/SparkRedshiftBuild.scala
+++ b/project/SparkRedshiftBuild.scala
@@ -113,7 +113,15 @@ object SparkRedshiftBuild extends Build {
           x => x.data.getName.contains("hadoop1") && x.data.getName.contains("avro")
         }
       }),
-      fullClasspath in IntegrationTest := (fullClasspath in Test).value,
+      (fullClasspath in IntegrationTest) := (if (testHadoopVersion.value.startsWith("1")) {
+        (fullClasspath in IntegrationTest).value.filterNot {
+          x => x.data.getName.contains("hadoop2") && x.data.getName.contains("avro")
+        }
+      } else {
+        (fullClasspath in IntegrationTest).value.filterNot {
+          x => x.data.getName.contains("hadoop1") && x.data.getName.contains("avro")
+        }
+      }),
       ScoverageSbtPlugin.ScoverageKeys.coverageHighlighting := {
         if (scalaBinaryVersion.value == "2.10") false
         else true

--- a/src/it/scala/com/databricks/spark/redshift/CredentialsInUriIntegrationSuite.scala
+++ b/src/it/scala/com/databricks/spark/redshift/CredentialsInUriIntegrationSuite.scala
@@ -43,10 +43,10 @@ class CredentialsInUriIntegrationSuite extends IntegrationSuiteBase {
 
   // Override this method so that we do not set the credentials in sc.hadoopConf.
   override def beforeAll(): Unit = {
-    sc = new SparkContext("local", getClass.getSimpleName)
-    conn = DefaultJDBCWrapper.getConnector(None, jdbcUrl)
     assert(tempDir.contains("AKIA"), "tempdir did not contain AWS credentials")
     assert(!AWS_SECRET_ACCESS_KEY.contains("/"), "AWS secret key should not contain slash")
+    sc = new SparkContext("local", getClass.getSimpleName)
+    conn = DefaultJDBCWrapper.getConnector(None, jdbcUrl)
   }
 
   test("roundtrip save and load") {

--- a/src/it/scala/com/databricks/spark/redshift/IntegrationSuiteBase.scala
+++ b/src/it/scala/com/databricks/spark/redshift/IntegrationSuiteBase.scala
@@ -23,6 +23,7 @@ import scala.util.Random
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{Path, FileSystem}
+import org.apache.hadoop.fs.s3native.NativeS3FileSystem
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.{DataFrame, SaveMode, SQLContext}
 import org.apache.spark.sql.hive.test.TestHiveContext
@@ -98,6 +99,8 @@ trait IntegrationSuiteBase
       // Bypass Hadoop's FileSystem caching mechanism so that we don't cache the credentials:
       conf.setBoolean("fs.s3.impl.disable.cache", true)
       conf.setBoolean("fs.s3n.impl.disable.cache", true)
+      conf.set("fs.s3.impl", classOf[NativeS3FileSystem].getCanonicalName)
+      conf.set("fs.s3n.impl", classOf[NativeS3FileSystem].getCanonicalName)
       val fs = FileSystem.get(URI.create(tempDir), conf)
       fs.delete(new Path(tempDir), true)
       fs.close()

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
@@ -105,7 +105,7 @@ private[redshift] case class RedshiftRelation(
       // Unload data from Redshift into a temporary directory in S3:
       val tempDir = params.createPerQueryTempDir()
       val unloadSql = buildUnloadStmt(requiredColumns, filters, tempDir)
-      log.info(unloadSql)
+      // log.info(unloadSql)
       val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl)
       try {
         conn.prepareStatement(unloadSql).execute()

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
@@ -105,7 +105,7 @@ private[redshift] case class RedshiftRelation(
       // Unload data from Redshift into a temporary directory in S3:
       val tempDir = params.createPerQueryTempDir()
       val unloadSql = buildUnloadStmt(requiredColumns, filters, tempDir)
-      // log.info(unloadSql)
+      log.info(unloadSql)
       val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl)
       try {
         conn.prepareStatement(unloadSql).execute()

--- a/src/test/resources/hive-site.xml
+++ b/src/test/resources/hive-site.xml
@@ -1,0 +1,28 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!-- The following is copied from https://issues.apache.org/jira/browse/HIVE-6962 -->
+
+<configuration>
+  <property>
+    <name>fs.permissions.umask-mode</name>
+    <value>022</value>
+    <description> Setting a value for fs.permissions.umask-mode to work around issue in HIVE-6962.
+      It has no impact in Hadoop 1.x line on HDFS operations.
+    </description>
+  </property>
+</configuration>


### PR DESCRIPTION
This patch fixes an issue where incorrect system properties were being used to specify the Spark and Hadoop versions during integration tests (the unit tests were using the correct properties).

Luckily I did not discover any bugs that would indicate broken Spark / Hadoop compatibility, although I did run into a few integration test configurations that needed to be updated in order to properly handle overridden dependencies.