### PR TITLE
Issue JDBC queries asynchronously in order to support cancellation / InterruptedException

### DIFF
--- a/src/main/scala/com/databricks/spark/redshift/RedshiftJDBCWrapper.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftJDBCWrapper.scala
@@ -41,15 +41,16 @@ private[redshift] class JDBCWrapper {
 
   private val ec: ExecutionContext = {
     val threadFactory = new ThreadFactory {
-      private val count = new AtomicInteger()
+      private[this] val count = new AtomicInteger()
       override def newThread(r: Runnable) = {
         val thread = new Thread(r)
         thread.setName(s"spark-redshift-JDBCWrapper-${count.incrementAndGet}")
         thread.setDaemon(true)
         thread
       }
-      ExecutionContext.fromExecutorService(Executors.newCachedThreadPool(threadFactory))
     }
+    ExecutionContext.fromExecutorService(Executors.newCachedThreadPool(threadFactory))
+  }
 
   /**
    * Given a JDBC subprotocol, returns the appropriate driver class so that it can be registered

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftJDBCWrapper.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftJDBCWrapper.scala
@@ -18,9 +18,12 @@
 package com.databricks.spark.redshift
 
 import java.net.URI
-import java.sql.{Connection, Driver, DriverManager, ResultSetMetaData, SQLException}
+import java.sql.{ResultSet, PreparedStatement, Connection, Driver, DriverManager, ResultSetMetaData, SQLException}
 import java.util.Properties
+import java.util.concurrent.Executors
 
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.duration.Duration
 import scala.util.Try
 
 import org.apache.spark.SPARK_VERSION
@@ -34,6 +37,9 @@ import org.slf4j.LoggerFactory
 private[redshift] class JDBCWrapper {
 
   private val log = LoggerFactory.getLogger(getClass)
+
+  private val ec: ExecutionContext =
+    ExecutionContext.fromExecutorService(Executors.newCachedThreadPool())
 
   /**
    * Given a JDBC subprotocol, returns the appropriate driver class so that it can be registered
@@ -89,6 +95,48 @@ private[redshift] class JDBCWrapper {
   }
 
   /**
+   * Execute the given SQL statement while supporting interruption.
+   * If InterruptedException is caught, then the statement will be cancelled if it is running.
+   *
+   * @return <code>true</code> if the first result is a <code>ResultSet</code>
+   *         object; <code>false</code> if the first result is an update
+   *         count or there is no result
+   */
+  def executeInterruptibly(statement: PreparedStatement): Boolean = {
+    executeInterruptibly(statement, _.execute())
+  }
+
+  /**
+   * Execute the given SQL statement while supporting interruption.
+   * If InterruptedException is caught, then the statement will be cancelled if it is running.
+   *
+   * @return a <code>ResultSet</code> object that contains the data produced by the
+   *         query; never <code>null</code>
+   */
+  def executeQueryInterruptibly(statement: PreparedStatement): ResultSet = {
+    executeInterruptibly(statement, _.executeQuery())
+  }
+
+  private def executeInterruptibly[T](
+      statement: PreparedStatement,
+      op: PreparedStatement => T): T = {
+    try {
+      val future = Future[T](op(statement))(ec)
+      Await.result(future, Duration.Inf)
+    } catch {
+      case e: InterruptedException =>
+        try {
+          statement.cancel()
+          throw e
+        } catch {
+          case s: SQLException =>
+            log.error("Exception occurred while cancelling query", s)
+            throw e
+        }
+    }
+  }
+
+  /**
    * Takes a (schema, table) specification and returns the table's Catalyst
    * schema.
    *
@@ -101,7 +149,7 @@ private[redshift] class JDBCWrapper {
    * @throws SQLException if the table contains an unsupported type.
    */
   def resolveTable(conn: Connection, table: String): StructType = {
-    val rs = conn.prepareStatement(s"SELECT * FROM $table WHERE 1=0").executeQuery()
+    val rs = executeQueryInterruptibly(conn.prepareStatement(s"SELECT * FROM $table WHERE 1=0"))
     try {
       val rsmd = rs.getMetaData
       val ncols = rsmd.getColumnCount
@@ -179,7 +227,9 @@ private[redshift] class JDBCWrapper {
   def tableExists(conn: Connection, table: String): Boolean = {
     // Somewhat hacky, but there isn't a good way to identify whether a table exists for all
     // SQL database systems, considering "table" could also include the database name.
-    Try(conn.prepareStatement(s"SELECT 1 FROM $table LIMIT 1").executeQuery().next()).isSuccess
+    Try {
+      executeQueryInterruptibly(conn.prepareStatement(s"SELECT 1 FROM $table LIMIT 1")).next()
+    }.isSuccess
   }
 
   /**

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
@@ -89,7 +89,7 @@ private[redshift] case class RedshiftRelation(
       log.info(countQuery)
       val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl)
       try {
-        val results = conn.prepareStatement(countQuery).executeQuery()
+        val results = jdbcWrapper.executeQueryInterruptibly(conn.prepareStatement(countQuery))
         if (results.next()) {
           val numRows = results.getLong(1)
           val parallelism = sqlContext.getConf("spark.sql.shuffle.partitions", "200").toInt
@@ -108,7 +108,7 @@ private[redshift] case class RedshiftRelation(
       log.info(unloadSql)
       val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl)
       try {
-        conn.prepareStatement(unloadSql).execute()
+        jdbcWrapper.executeInterruptibly(conn.prepareStatement(unloadSql))
       } finally {
         conn.close()
       }


### PR DESCRIPTION
Most blocking JDBC calls do not respond to InterruptedException, which causes problems when users try to cancel long-running `spark-redshift` loads or unloads. This patch addresses this issue by using issuing the blocking JDBC calls in Futures.

Fixes #116.