### PR TITLE
Re-use Row instance itself in row conversion function

### DIFF
--- a/src/main/scala/com/databricks/spark/redshift/Conversions.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Conversions.scala
@@ -22,7 +22,7 @@ import java.util.Date
 
 import scala.collection.mutable
 
-import org.apache.spark.sql.catalyst.expressions.GenericMutableRow
+import org.apache.spark.sql.catalyst.expressions.GenericRow
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.Row
 
@@ -90,7 +90,9 @@ private[redshift] object Conversions {
     }
     // As a performance optimization, re-use a single row that is backed by a mutable Seq:
     val converted: Array[Any] = Array.fill(schema.length)(null)
-    val row = new GenericMutableRow(converted)
+    val row = new GenericRow(converted) {
+      override def copy(): Row = new GenericRow(values.clone())
+    }
     (fields: Array[String]) => {
       var i = 0
       while (i < schema.length) {

--- a/src/main/scala/com/databricks/spark/redshift/Conversions.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Conversions.scala
@@ -22,6 +22,7 @@ import java.util.Date
 
 import scala.collection.mutable
 
+import org.apache.spark.sql.catalyst.expressions.GenericMutableRow
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.Row
 
@@ -88,8 +89,8 @@ private[redshift] object Conversions {
       }
     }
     // As a performance optimization, re-use a single row that is backed by a mutable Seq:
-    val converted: mutable.IndexedSeq[Any] = mutable.IndexedSeq.fill(schema.length)(null)
-    val row = Row.fromSeq(converted)
+    val converted: Array[Any] = Array.fill(schema.length)(null)
+    val row = new GenericMutableRow(converted)
     (fields: Array[String]) => {
       var i = 0
       while (i < schema.length) {

--- a/src/main/scala/com/databricks/spark/redshift/Conversions.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Conversions.scala
@@ -87,8 +87,9 @@ private[redshift] object Conversions {
         case _ => (data: String) => data
       }
     }
-    // As a performance optimization, re-use the same mutable Seq:
+    // As a performance optimization, re-use the same row, which is backed by a mutable Seq:
     val converted: mutable.IndexedSeq[Any] = mutable.IndexedSeq.fill(schema.length)(null)
+    val row = Row.fromSeq(converted)
     (fields: Array[String]) => {
       var i = 0
       while (i < schema.length) {
@@ -96,7 +97,7 @@ private[redshift] object Conversions {
         converted(i) = if (data == null || data.isEmpty) null else conversionFunctions(i)(data)
         i += 1
       }
-      Row.fromSeq(converted)
+      row
     }
   }
 }

--- a/src/main/scala/com/databricks/spark/redshift/Conversions.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Conversions.scala
@@ -87,7 +87,7 @@ private[redshift] object Conversions {
         case _ => (data: String) => data
       }
     }
-    // As a performance optimization, re-use the same row, which is backed by a mutable Seq:
+    // As a performance optimization, re-use a single row that is backed by a mutable Seq:
     val converted: mutable.IndexedSeq[Any] = mutable.IndexedSeq.fill(schema.length)(null)
     val row = Row.fromSeq(converted)
     (fields: Array[String]) => {

--- a/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
@@ -204,7 +204,7 @@ class RedshiftSourceSuite
     val relation = source.createRelation(testSqlContext, defaultParams, TestUtils.testSchema)
 
     val rdd = relation.asInstanceOf[PrunedFilteredScan]
-      .buildScan(Array("testbyte", "testbool"), Array.empty[Filter])
+      .buildScan(Array("testbyte", "testbool"), Array.empty[Filter]).map(_.copy())
     val prunedExpectedValues = Array(
       Row(1.toByte, true),
       Row(1.toByte, false),
@@ -250,7 +250,7 @@ class RedshiftSourceSuite
       GreaterThanOrEqual("testfloat", 1.0f),
       LessThanOrEqual("testint", 43))
     val rdd = relation.asInstanceOf[PrunedFilteredScan]
-      .buildScan(Array("testbyte", "testbool"), filters)
+      .buildScan(Array("testbyte", "testbool"), filters).map(_.copy())
 
     // Technically this assertion should check that the RDD only returns a single row, but
     // since we've mocked out Redshift our WHERE clause won't have had any effect.


### PR DESCRIPTION
As a minor performance optimization, we can re-use the same `Row` instance itself in the row converter function. 