### PR TITLE
Implement Spark 1.6's new unhandledFilters API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,10 @@ matrix:
     - jdk: openjdk7
       scala: 2.10.5
       env: HADOOP_VERSION="2.2.0" SPARK_VERSION="1.5.0" SPARK_AVRO_VERSION="2.0.1"
+    # Tests against Spark 1.6.0-SNAPHSOT, to be updated once 1.6.0 is released:
+    - jdk: openjdk7
+      scala: 2.10.5
+      env: HADOOP_VERSION="2.2.0" SPARK_VERSION="1.6.0-SNAPSHOT" SPARK_AVRO_VERSION="2.0.1"
     # Configuration corresponding to DBC 1.4.x driver package as of DBC 2.4,
     # which uses spark-avro 1.0.0. We use Hadoop 2.2.0 here, while DBC uses
     # 1.2.1, because the 1.4.1 published to Maven Central is a Hadoop 2.x build.

--- a/project/SparkRedshiftBuild.scala
+++ b/project/SparkRedshiftBuild.scala
@@ -53,8 +53,10 @@ object SparkRedshiftBuild extends Build {
       spIgnoreProvided := true,
       licenses += "Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0"),
       credentials += Credentials(Path.userHome / ".ivy2" / ".credentials"),
-      resolvers +=
+      resolvers ++= Seq(
         "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
+        "ASF Snapshots" at "http://repository.apache.org/snapshots/"
+      ),
       scalacOptions ++= Seq("-target:jvm-1.6"),
       javacOptions ++= Seq("-source", "1.6", "-target", "1.6"),
       libraryDependencies ++= Seq(

--- a/src/main/scala/com/databricks/spark/redshift/FilterPushdown.scala
+++ b/src/main/scala/com/databricks/spark/redshift/FilterPushdown.scala
@@ -41,7 +41,7 @@ private[redshift] object FilterPushdown {
    * Attempt to convert the given filter into a SQL expression. Returns None if the expression
    * could not be converted.
    */
-  private def buildFilterExpression(schema: StructType, filter: Filter): Option[String] = {
+  def buildFilterExpression(schema: StructType, filter: Filter): Option[String] = {
     def buildComparison(attr: String, value: Any, comparisonOp: String): Option[String] = {
      getTypeForAttribute(schema, attr).map { dataType =>
        val sqlEscapedValue: String = dataType match {

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
@@ -77,6 +77,13 @@ private[redshift] case class RedshiftRelation(
     writer.saveToRedshift(sqlContext, data, saveMode, params)
   }
 
+  // In Spark 1.6+, this method allows a data source to declare which filters it handles, allowing
+  // Spark to skip its own defensive filtering. See SPARK-10978 for more details. As long as we
+  // compile against Spark 1.4, we cannot use the `override` modifier here.
+  def unhandledFilters(filters: Array[Filter]): Array[Filter] = {
+    filters.filterNot(filter => FilterPushdown.buildFilterExpression(schema, filter).isDefined)
+  }
+
   override def buildScan(requiredColumns: Array[String], filters: Array[Filter]): RDD[Row] = {
     val creds =
       AWSCredentialsUtils.load(params.rootTempDir, sqlContext.sparkContext.hadoopConfiguration)


### PR DESCRIPTION
Spark 1.6 extends `BaseRelation` with a new API which allows data sources to tell Spark which filters they handle, allowing Spark to eliminate its own defensive filtering for filters that are handled by the data source (see https://github.com/apache/spark/pull/9399 for more details).

This patch implements this new API in `spark-redshift` and adds tests.