### PR TITLE
Change RedshiftWriter Dateformat to yyyy-MM-dd

### DIFF
--- a/src/main/scala/com/databricks/spark/redshift/Conversions.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Conversions.scala
@@ -148,9 +148,9 @@ private[redshift] class RedshiftDateFormat extends DateFormat {
   private val redshiftDateFormat = new SimpleDateFormat(PATTERN)
 
   override def format(
-                       date: Date,
-                       toAppendTo: StringBuffer,
-                       fieldPosition: FieldPosition): StringBuffer = {
+     date: Date,
+     toAppendTo: StringBuffer,
+     fieldPosition: FieldPosition): StringBuffer = {
     redshiftDateFormat.format(date, toAppendTo, fieldPosition)
   }
 

--- a/src/main/scala/com/databricks/spark/redshift/Conversions.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Conversions.scala
@@ -138,3 +138,23 @@ private[redshift] class RedshiftTimestampFormat extends DateFormat {
     }
   }
 }
+
+private[redshift] class RedshiftDateFormat extends DateFormat {
+
+  // Imports and exports with Redshift require that dates are represented
+  // as strings, using the following format
+  private val PATTERN = "yyyy-MM-dd"
+
+  private val redshiftDateFormat = new SimpleDateFormat(PATTERN)
+
+  override def format(
+                       date: Date,
+                       toAppendTo: StringBuffer,
+                       fieldPosition: FieldPosition): StringBuffer = {
+    redshiftDateFormat.format(date, toAppendTo, fieldPosition)
+  }
+
+  override def parse(source: String, pos: ParsePosition): Date = {
+    redshiftDateFormat.parse(source, pos)
+  }
+}

--- a/src/test/scala/com/databricks/spark/redshift/ConversionsSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/ConversionsSuite.scala
@@ -17,6 +17,8 @@
 package com.databricks.spark.redshift
 
 import java.sql.Timestamp
+import java.sql.Date
+import java.text.SimpleDateFormat
 
 import org.scalatest.FunSuite
 
@@ -37,6 +39,7 @@ class ConversionsSuite extends FunSuite {
     // scalastyle:on
 
     val timestampWithMillis = "2014-03-01 00:00:01.123"
+    val dateFormat = new SimpleDateFormat("yyyy-DD-mm")
 
     val expectedDateMillis = TestUtils.toMillis(2015, 6, 1, 0, 0, 0)
     val expectedTimestampMillis = TestUtils.toMillis(2014, 2, 1, 0, 0, 1, 123)
@@ -45,7 +48,7 @@ class ConversionsSuite extends FunSuite {
       Array("1", "t", "2015-07-01", doubleMin, "1.0", "42",
         longMax, "23", unicodeString, timestampWithMillis))
 
-    val expectedRow = Row(1.asInstanceOf[Byte], true, new Timestamp(expectedDateMillis),
+    val expectedRow = Row(1.asInstanceOf[Byte], true, new Date(expectedDateMillis),
       Double.MinValue, 1.0f, 42, Long.MaxValue, 23.toShort, unicodeString,
       new Timestamp(expectedTimestampMillis))
 

--- a/src/test/scala/com/databricks/spark/redshift/ConversionsSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/ConversionsSuite.scala
@@ -17,8 +17,6 @@
 package com.databricks.spark.redshift
 
 import java.sql.Timestamp
-import java.sql.Date
-import java.text.SimpleDateFormat
 
 import org.scalatest.FunSuite
 
@@ -39,7 +37,6 @@ class ConversionsSuite extends FunSuite {
     // scalastyle:on
 
     val timestampWithMillis = "2014-03-01 00:00:01.123"
-    val dateFormat = new SimpleDateFormat("yyyy-DD-mm")
 
     val expectedDateMillis = TestUtils.toMillis(2015, 6, 1, 0, 0, 0)
     val expectedTimestampMillis = TestUtils.toMillis(2014, 2, 1, 0, 0, 1, 123)
@@ -48,7 +45,7 @@ class ConversionsSuite extends FunSuite {
       Array("1", "t", "2015-07-01", doubleMin, "1.0", "42",
         longMax, "23", unicodeString, timestampWithMillis))
 
-    val expectedRow = Row(1.asInstanceOf[Byte], true, new Date(expectedDateMillis),
+    val expectedRow = Row(1.asInstanceOf[Byte], true, new Timestamp(expectedDateMillis),
       Double.MinValue, 1.0f, 42, Long.MaxValue, 23.toShort, unicodeString,
       new Timestamp(expectedTimestampMillis))
 

--- a/src/test/scala/com/databricks/spark/redshift/TestUtils.scala
+++ b/src/test/scala/com/databricks/spark/redshift/TestUtils.scala
@@ -69,7 +69,7 @@ object TestUtils {
   val expectedDataWithConvertedTimesAndDates: Seq[Row] = expectedData.map { row =>
     Row.fromSeq(row.toSeq.map {
       case t: Timestamp => new RedshiftTimestampFormat().format(t)
-      case d: Date => new RedshiftTimestampFormat().format(d)
+      case d: Date => new RedshiftDateFormat().format(d)
       case other => other
     })
   }


### PR DESCRIPTION
This patch modifies the write path to write dates in `yyyy-MM-dd` format instead of the timestamp format. See #122 for more details.