### PR TITLE
Directly parse subprotocol from JDBC connection string, rather than constructing a URI

### DIFF
--- a/src/main/scala/com/databricks/spark/redshift/RedshiftJDBCWrapper.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftJDBCWrapper.scala
@@ -193,7 +193,7 @@ private[redshift] class JDBCWrapper {
    * @param url the JDBC url to connect to.
    */
   def getConnector(userProvidedDriverClass: Option[String], url: String): Connection = {
-    val subprotocol = new URI(url.stripPrefix("jdbc:")).getScheme
+    val subprotocol = url.stripPrefix("jdbc:").split(":")(0)
     val driverClass: Class[Driver] = getDriverClass(subprotocol, userProvidedDriverClass)
     registerDriver(driverClass.getCanonicalName)
     DriverManager.getConnection(url, new Properties())


### PR DESCRIPTION
The connection string has query parameters, including Redshift login and password, which have illegal URI characters.  The query is only parsed as a URI in one instance: when the subprotocol is recovered - in other words, to recover 'postgres' from the following string:

`jdbc:postgres://redshifthost:5439/database?user=username&password=pass`

This could also be done by simply splitting, but that would make `jdbc:` non-optional (`.stripPrefix` will not fail if `jdbc:` is not present):  

`val subprotocol = url.split(":")(1)`

Another option would be to enforce that all query parameters in the connection string should be URL-encoded.  This would make the connection string a correct URI, but would require other changes in the codebase, and would break existing applications.  It is not possible to have the encoding be automatically detected, as the escape characters are valid password characters.