### PR TITLE
Minor fixes to unit test mocks in order to suppress spurious exceptions

### DIFF
--- a/src/test/scala/com/databricks/spark/redshift/MockRedshift.scala
+++ b/src/test/scala/com/databricks/spark/redshift/MockRedshift.scala
@@ -16,7 +16,7 @@
 
 package com.databricks.spark.redshift
 
-import java.sql.{SQLException, PreparedStatement, Connection}
+import java.sql.{Connection, PreparedStatement, ResultSet, SQLException}
 
 import scala.collection.mutable
 import scala.util.matching.Regex
@@ -54,8 +54,11 @@ class MockRedshift(
         val mockStatement = mock(classOf[PreparedStatement], RETURNS_SMART_NULLS)
         if (jdbcQueriesThatShouldFail.forall(_.findFirstMatchIn(query).isEmpty)) {
           when(mockStatement.execute()).thenReturn(true)
+          when(mockStatement.executeQuery()).thenReturn(
+            mock(classOf[ResultSet], RETURNS_SMART_NULLS))
         } else {
           when(mockStatement.execute()).thenThrow(new SQLException(s"Error executing $query"))
+          when(mockStatement.executeQuery()).thenThrow(new SQLException(s"Error executing $query"))
         }
         mockStatement
       }

--- a/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
@@ -101,12 +101,6 @@ class RedshiftSourceSuite
     sc.hadoopConfiguration.set("fs.s3.awsSecretAccessKey", "test2")
     sc.hadoopConfiguration.set("fs.s3n.awsAccessKeyId", "test1")
     sc.hadoopConfiguration.set("fs.s3n.awsSecretAccessKey", "test2")
-    // Configure a mock S3 client so that we don't hit errors when trying to access AWS in tests.
-    mockS3Client = Mockito.mock(classOf[AmazonS3Client], Mockito.RETURNS_SMART_NULLS)
-    when(mockS3Client.getBucketLifecycleConfiguration(anyString())).thenReturn(
-      new BucketLifecycleConfiguration().withRules(
-        new Rule().withPrefix("").withStatus(BucketLifecycleConfiguration.ENABLED)
-      ))
   }
 
   override def beforeEach(): Unit = {
@@ -115,6 +109,12 @@ class RedshiftSourceSuite
     testSqlContext = new SQLContext(sc)
     expectedDataDF =
       testSqlContext.createDataFrame(sc.parallelize(TestUtils.expectedData), TestUtils.testSchema)
+    // Configure a mock S3 client so that we don't hit errors when trying to access AWS in tests.
+    mockS3Client = Mockito.mock(classOf[AmazonS3Client], Mockito.RETURNS_SMART_NULLS)
+    when(mockS3Client.getBucketLifecycleConfiguration(anyString())).thenReturn(
+      new BucketLifecycleConfiguration().withRules(
+        new Rule().withPrefix("").withStatus(BucketLifecycleConfiguration.ENABLED)
+      ))
   }
 
   override def afterEach(): Unit = {


### PR DESCRIPTION
This patch contains two minor bug fixes related to unit test mocks:

- In `RedshiftSourceSuite`, `mockS3Client` needs to be created in `beforeEach` instead of in `beforeAll`; the old behavior was causing NullPointerExceptions in tests because the `afterEach` method would teardown the `mockS3Client` but it would never be re-created for later tests.
- In `MockRedshift`, we need to stub both `execute()` _and_ `executeQuery()` when mocking a `PreparedStatement`; this is necessary after the changes in #117.