### PR TITLE
Handle non-existent bucket in bucket lifecycle check

### DIFF
--- a/src/main/scala/com/databricks/spark/redshift/Utils.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Utils.scala
@@ -89,20 +89,25 @@ private[redshift] object Utils {
     try {
       val s3URI = new AmazonS3URI(Utils.fixS3Url(tempDir))
       val bucket = s3URI.getBucket
-      val bucketLifecycleConfiguration = s3Client.getBucketLifecycleConfiguration(bucket)
+      assert(bucket != null, "Could not get bucket from S3 URI")
       val key = Option(s3URI.getKey).getOrElse("")
-      val someRuleMatchesTempDir = bucketLifecycleConfiguration.getRules.asScala.exists { rule =>
-        // Note: this only checks that there is an active rule which matches the temp directory;
-        // it does not actually check that the rule will delete the files. This check is still
-        // better than nothing, though, and we can always improve it later.
-        rule.getStatus == BucketLifecycleConfiguration.ENABLED && key.startsWith(rule.getPrefix)
-      }
-      if (!someRuleMatchesTempDir) {
-        log.warn(s"The S3 bucket $bucket does not have an object lifecycle configuration to " +
-          "ensure cleanup of temporary files. Consider configuring `tempdir` to point to a " +
-          "bucket with an object lifecycle policy that automatically deletes files after an " +
-          "expiration period. For more information, see " +
-          "https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html")
+      Option(s3Client.getBucketLifecycleConfiguration(bucket)) match {
+        case None =>
+          log.error(s"The S3 bucket $bucket does not exist")
+        case Some(lifecycleConfiguration) =>
+          val someRuleMatchesTempDir = lifecycleConfiguration.getRules.asScala.exists { rule =>
+            // Note: this only checks that there is an active rule which matches the temp directory;
+            // it does not actually check that the rule will delete the files. This check is still
+            // better than nothing, though, and we can always improve it later.
+            rule.getStatus == BucketLifecycleConfiguration.ENABLED && key.startsWith(rule.getPrefix)
+          }
+          if (!someRuleMatchesTempDir) {
+            log.warn(s"The S3 bucket $bucket does not have an object lifecycle configuration to " +
+              "ensure cleanup of temporary files. Consider configuring `tempdir` to point to a " +
+              "bucket with an object lifecycle policy that automatically deletes files after an " +
+              "expiration period. For more information, see " +
+              "https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html")
+          }
       }
     } catch {
       case NonFatal(e) =>


### PR DESCRIPTION
This patch improves the error-handling in `Utils.checkThatBucketHasObjectLifecycleConfiguration` so that non-existent buckets result in a proper error message rather than a confusing NullPointerException (see #138).