### PR TITLE
Fix bugs related to JDBC driver precedence and PostgreSQL JDBC subprotocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ and use that as a temp location for this data.
     <td><tt>jdbcdriver</tt></td>
     <td>No</td>
     <td>Determined by the JDBC URL's subprotocol</td>
-    <td>The class name of the JDBC driver to load before JDBC operations. This class must be on the classpath. In most cases, it should not be necessary to specify this option, as the appropriate driver classname should automatically be determined by the JDBC URL's subprotocol.</td>
+    <td>The class name of the JDBC driver to use. This class must be on the classpath. In most cases, it should not be necessary to specify this option, as the appropriate driver classname should automatically be determined by the JDBC URL's subprotocol.</td>
  </tr>
  <tr>
     <td><tt>diststyle</tt></td>

--- a/project/SparkRedshiftBuild.scala
+++ b/project/SparkRedshiftBuild.scala
@@ -86,6 +86,9 @@ object SparkRedshiftBuild extends Build {
         // For testing, we use an Amazon driver, which is available from
         // http://docs.aws.amazon.com/redshift/latest/mgmt/configure-jdbc-connection.html
         "com.amazon.redshift" % "jdbc4" % "1.1.7.1007" % "test" from "https://s3.amazonaws.com/redshift-downloads/drivers/RedshiftJDBC4-1.1.7.1007.jar",
+        // Although support for the postgres driver is lower priority than support for Amazon's
+        // official Redshift driver, we still run basic tests with it.
+        "postgresql" % "postgresql" % "8.3-606.jdbc4" % "test",
         "com.google.guava" % "guava" % "14.0.1" % "test",
         "org.scalatest" %% "scalatest" % "2.2.1" % "test",
         "org.mockito" % "mockito-core" % "1.10.19" % "test"

--- a/src/it/scala/com/databricks/spark/redshift/IntegrationSuiteBase.scala
+++ b/src/it/scala/com/databricks/spark/redshift/IntegrationSuiteBase.scala
@@ -60,7 +60,7 @@ trait IntegrationSuiteBase
   protected val AWS_S3_SCRATCH_SPACE: String = loadConfigFromEnv("AWS_S3_SCRATCH_SPACE")
   require(AWS_S3_SCRATCH_SPACE.contains("s3n"), "must use s3n:// URL")
 
-  protected val jdbcUrl: String = {
+  protected def jdbcUrl: String = {
     s"$AWS_REDSHIFT_JDBC_URL?user=$AWS_REDSHIFT_USER&password=$AWS_REDSHIFT_PASSWORD"
   }
 

--- a/src/it/scala/com/databricks/spark/redshift/PostgresDriverIntegrationSuite.scala
+++ b/src/it/scala/com/databricks/spark/redshift/PostgresDriverIntegrationSuite.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015 Databricks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.databricks.spark.redshift
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
+
+/**
+  * Basic integration tests with the Postgres JDBC driver.
+  */
+class PostgresDriverIntegrationSuite extends IntegrationSuiteBase {
+
+  override def jdbcUrl: String = {
+    super.jdbcUrl.replace("jdbc:redshift", "jdbc:postgresql")
+  }
+
+  test("postgresql driver takes precedence for jdbc:postgresql:// URIs") {
+    val conn = DefaultJDBCWrapper.getConnector(None, jdbcUrl)
+    try {
+      assert(conn.getClass.getName === "org.postgresql.jdbc4.Jdbc4Connection")
+    } finally {
+      conn.close()
+    }
+  }
+
+  test("roundtrip save and load") {
+    val df = sqlContext.createDataFrame(sc.parallelize(Seq(Row(1)), 1),
+      StructType(StructField("foo", IntegerType) :: Nil))
+    testRoundtripSaveAndLoad(s"save_with_one_empty_partition_$randomSuffix", df)
+  }
+}


### PR DESCRIPTION
This patch fixes two bugs related to JDBC drivers:

- The `RedshiftJDBCWrapper.getDriverClass` method mistakenly used `postgres` as the PostgreSQL JDBC subprotocol, whereas the correct subprotocol is actually `postgresql` (see #126). This was straightforward to fix.
- When the user specified an explicit JDBC driver class, we would register that driver with the JDBC DriverManager but would not necessarily use it to create connections. In a nutshell, the problem is that you might have multiple JDBC drivers on your classpath that claim to be able to handle the same subprotocol and there doesn't seem to be an intuitive way to control which of those drivers takes precedence. The change implemented in this patch is to iterate over the driver registry's loaded drivers in order to obtain the correct driver and then use that driver to create a connection.

Fixes #126.