### PR TITLE
Use MANIFEST in unload to guard against eventually-consistent S3 bucket listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,9 +411,7 @@ In a future release, this will be changed so that the temporary table is created
 
 This use of a staging table can be disabled by setting `usestagingtable` to `false`, in which case the destination table will be deleted before the `COPY`, sacrificing the atomicity of the overwrite operation.
 
-**Querying Redshift tables**: Queries use Redshift's [`UNLOAD`](https://docs.aws.amazon.com/redshift/latest/dg/r_UNLOAD.html) command to execute a query and save its results to S3. The data which is written to S3 should reflect a consistent snapshot of the database.
-
-In `spark-redshift` 1.6.0 and earlier, the S3 read path performs bucket-listing and thus may be impacted by the eventually-consistent nature of this S3 operation, meaning that in rare circumstances reads may see reflect a subset of the unloaded data stored in S3. This will be fixed in future releases by using `UNLOAD`'s `MANIFEST` support.
+**Querying Redshift tables**: Queries use Redshift's [`UNLOAD`](https://docs.aws.amazon.com/redshift/latest/dg/r_UNLOAD.html) command to execute a query and save its results to S3 and use [manifests](https://docs.aws.amazon.com/redshift/latest/dg/loading-data-files-using-manifest.html) to guard against certain eventually-consistent S3 operations. As a result, `spark-redshift` queries should have the same consistency properties as regular Redshift queries.
 
 ## Migration Guide
 

--- a/project/SparkRedshiftBuild.scala
+++ b/project/SparkRedshiftBuild.scala
@@ -59,6 +59,7 @@ object SparkRedshiftBuild extends Build {
       javacOptions ++= Seq("-source", "1.6", "-target", "1.6"),
       libraryDependencies ++= Seq(
         "org.slf4j" % "slf4j-api" % "1.7.5",
+        "com.eclipsesource.minimal-json" % "minimal-json" % "0.9.4",
         // These Amazon SDK depdencies are marked as 'provided' in order to reduce the risk of
         // dependency conflicts with other user libraries. In many environments, such as EMR and
         // Databricks, the Amazon SDK will already be on the classpath. In other cases, the SDK is

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
@@ -16,11 +16,15 @@
 
 package com.databricks.spark.redshift
 
+import java.io.InputStreamReader
+import java.lang
 import java.net.URI
 
+import scala.collection.JavaConverters._
+
 import com.amazonaws.auth.AWSCredentials
-import com.amazonaws.services.s3.AmazonS3Client
-import org.apache.hadoop.conf.Configuration
+import com.amazonaws.services.s3.{AmazonS3Client, AmazonS3URI}
+import com.eclipsesource.json.Json
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types._
@@ -119,12 +123,38 @@ private[redshift] case class RedshiftRelation(
       } finally {
         conn.close()
       }
+      // Read the MANIFEST file to get the list of S3 part files that were written by Redshift.
+      // We need to use a manifest in order to guard against S3's eventually-consistent listings.
+      val filesToRead: Seq[String] = {
+        val cleanedTempDirUri =
+          Utils.fixS3Url(Utils.removeCredentialsFromURI(URI.create(tempDir)).toString)
+        val s3URI = new AmazonS3URI(cleanedTempDirUri)
+        val s3Client = s3ClientFactory(creds)
+        val is = s3Client.getObject(s3URI.getBucket, s3URI.getKey + "manifest").getObjectContent
+        val s3Files = try {
+          val entries = Json.parse(new InputStreamReader(is)).asObject().get("entries").asArray()
+          entries.iterator().asScala.map(_.asObject().get("url").asString()).toSeq
+        } finally {
+          is.close()
+        }
+        // The filenames in the manifest are of the form s3://bucket/key, without credentials.
+        // If the S3 credentials were originally specified in the tempdir's URI, then we need to
+        // reintroduce them here
+        s3Files.map { file =>
+          tempDir.stripSuffix("/") + '/' + file.stripPrefix(cleanedTempDirUri).stripPrefix("/")
+        }
+      }
       // Create a DataFrame to read the unloaded data:
-      val rdd = sqlContext.sparkContext.newAPIHadoopFile(
-        tempDir,
-        classOf[RedshiftInputFormat],
-        classOf[java.lang.Long],
-        classOf[Array[String]])
+      val rdd: RDD[(lang.Long, Array[String])] = {
+        val rdds = filesToRead.map { file =>
+          sqlContext.sparkContext.newAPIHadoopFile(
+            file,
+            classOf[RedshiftInputFormat],
+            classOf[java.lang.Long],
+            classOf[Array[String]])
+        }.toArray
+        sqlContext.sparkContext.union(rdds)
+      }
       val prunedSchema = pruneSchema(schema, requiredColumns)
       rdd.values.mapPartitions { iter =>
         val converter: Array[String] => Row = Conversions.createRowConverter(prunedSchema)
@@ -154,7 +184,7 @@ private[redshift] case class RedshiftRelation(
     // the credentials passed via `credsString`.
     val fixedUrl = Utils.fixS3Url(Utils.removeCredentialsFromURI(new URI(tempDir)).toString)
 
-    s"UNLOAD ('$query') TO '$fixedUrl' WITH CREDENTIALS '$credsString' ESCAPE"
+    s"UNLOAD ('$query') TO '$fixedUrl' WITH CREDENTIALS '$credsString' ESCAPE MANIFEST"
   }
 
   private def pruneSchema(schema: StructType, columns: Array[String]): StructType = {


### PR DESCRIPTION
This patch modifies `spark-redshift`'s read path in order to guard against a potential source of missing data / inconsistent reads.

According to the [Amazon S3 Data Consistency Model](https://docs.aws.amazon.com/AmazonS3/latest/dev/Introduction.html#ConsistencyModel) documentation, S3 bucket listing is eventually-consistent. In `spark-redshift` 1.6.0 and earlier, the S3 read path performs bucket-listing and thus may be impacted by this eventual-consistency, meaning that in rare circumstances reads may see only a subset of the unloaded data.

This patch fixes this issue by using [`UNLOAD`](https://docs.aws.amazon.com/redshift/latest/dg/r_UNLOAD.html) command's the `MANIFEST` parameter, which causes it to write a JSON manifest which lists the paths of all unload output files. I modified the UNLOAD query to produce this manifest and added some code to the reader to consume it. In order to simplify parsing of the JSON manifest, I used the [minimal-json](https://github.com/ralfstx/minimal-json) JSON library, chosen because it's small and has no external dependencies (and thus is unlikely to cause the sorts of dependency conflicts that something like Jackson would lead to).