### PR TITLE
Quote dates and timestamps constants when pushing down filters to Redshift

### DIFF
--- a/src/it/scala/com/databricks/spark/redshift/RedshiftIntegrationSuite.scala
+++ b/src/it/scala/com/databricks/spark/redshift/RedshiftIntegrationSuite.scala
@@ -534,4 +534,15 @@ class RedshiftIntegrationSuite extends IntegrationSuiteBase {
       sqlContext.sql("select * from test_table"),
       TestUtils.expectedData)
   }
+
+  test("filtering based on date constants (regression test for #152)") {
+    val date = TestUtils.toDate(year = 2015, zeroBasedMonth = 6, date = 3)
+    val df = sqlContext.sql("select testdate from test_table")
+
+    checkAnswer(df.filter(df("testdate") === date), Seq(Row(date)))
+    // This query failed in Spark 1.6.0 but not in earlier versions. It looks like 1.6.0 performs
+    // constant-folding, whereas earlier Spark versions would preserve the cast which prevented
+    // filter pushdown.
+    checkAnswer(df.filter("testdate = to_date('2015-07-03')"), Seq(Row(date)))
+  }
 }

--- a/src/it/scala/com/databricks/spark/redshift/RedshiftIntegrationSuite.scala
+++ b/src/it/scala/com/databricks/spark/redshift/RedshiftIntegrationSuite.scala
@@ -545,4 +545,15 @@ class RedshiftIntegrationSuite extends IntegrationSuiteBase {
     // filter pushdown.
     checkAnswer(df.filter("testdate = to_date('2015-07-03')"), Seq(Row(date)))
   }
+
+  test("filtering based on timestamp constants (regression test for #152)") {
+    val timestamp = TestUtils.toTimestamp(2015, zeroBasedMonth = 6, 1, 0, 0, 0, 1)
+    val df = sqlContext.sql("select testtimestamp from test_table")
+
+    checkAnswer(df.filter(df("testtimestamp") === timestamp), Seq(Row(timestamp)))
+    // This query failed in Spark 1.6.0 but not in earlier versions. It looks like 1.6.0 performs
+    // constant-folding, whereas earlier Spark versions would preserve the cast which prevented
+    // filter pushdown.
+    checkAnswer(df.filter("testtimestamp = '2015-07-01 00:00:00.001'"), Seq(Row(timestamp)))
+  }
 }

--- a/src/main/scala/com/databricks/spark/redshift/FilterPushdown.scala
+++ b/src/main/scala/com/databricks/spark/redshift/FilterPushdown.scala
@@ -17,7 +17,7 @@
 package com.databricks.spark.redshift
 
 import org.apache.spark.sql.sources._
-import org.apache.spark.sql.types.{DataType, StringType, StructType}
+import org.apache.spark.sql.types._
 
 /**
  * Helper methods for pushing filters into Redshift queries.
@@ -46,6 +46,7 @@ private[redshift] object FilterPushdown {
      getTypeForAttribute(schema, attr).map { dataType =>
        val sqlEscapedValue: String = dataType match {
          case StringType => s"\\'${value.toString.replace("'", "\\'\\'")}\\'"
+         case DateType | TimestampType => s"\\'$value\\'"
          case _ => value.toString
        }
        s""""$attr" $comparisonOp $sqlEscapedValue"""

--- a/src/main/scala/com/databricks/spark/redshift/FilterPushdown.scala
+++ b/src/main/scala/com/databricks/spark/redshift/FilterPushdown.scala
@@ -52,7 +52,7 @@ private[redshift] object FilterPushdown {
           // Workaround for SPARK-10195: prior to Spark 1.5.0, the Data Sources API exposed internal
           // types, so we must perform conversions if running on older versions:
           if (SPARK_VERSION < "1.5.0") {
-            CatalystTypeConverters.convertToScala(internalValue, DateType)
+            CatalystTypeConverters.convertToScala(internalValue, dataType)
           } else {
             internalValue
           }

--- a/src/main/scala/com/databricks/spark/redshift/FilterPushdown.scala
+++ b/src/main/scala/com/databricks/spark/redshift/FilterPushdown.scala
@@ -16,6 +16,10 @@
 
 package com.databricks.spark.redshift
 
+import java.sql.{Date, Timestamp}
+
+import org.apache.spark.SPARK_VERSION
+import org.apache.spark.sql.catalyst.CatalystTypeConverters
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types._
 
@@ -42,11 +46,21 @@ private[redshift] object FilterPushdown {
    * could not be converted.
    */
   def buildFilterExpression(schema: StructType, filter: Filter): Option[String] = {
-    def buildComparison(attr: String, value: Any, comparisonOp: String): Option[String] = {
-     getTypeForAttribute(schema, attr).map { dataType =>
+    def buildComparison(attr: String, internalValue: Any, comparisonOp: String): Option[String] = {
+      getTypeForAttribute(schema, attr).map { dataType =>
+        val value: Any = {
+          // Workaround for SPARK-10195: prior to Spark 1.5.0, the Data Sources API exposed internal
+          // types, so we must perform conversions if running on older versions:
+          if (SPARK_VERSION < "1.5.0") {
+            CatalystTypeConverters.convertToScala(internalValue, DateType)
+          } else {
+            internalValue
+          }
+        }
        val sqlEscapedValue: String = dataType match {
          case StringType => s"\\'${value.toString.replace("'", "\\'\\'")}\\'"
-         case DateType | TimestampType => s"\\'$value\\'"
+         case DateType => s"\\'${value.asInstanceOf[Date]}\\'"
+         case TimestampType => s"\\'${value.asInstanceOf[Timestamp]}\\'"
          case _ => value.toString
        }
        s""""$attr" $comparisonOp $sqlEscapedValue"""


### PR DESCRIPTION
This patch fixes an issue which could lead to incorrect results for queries which contained filters with date or timestamp constants. We need to quote the date and timestamp literals in order to prevent them from being interpreted as arithmetic expressions or producing syntax errors. For more details, see #152.

Fixes #152.

/cc @gregrahn, who reported this issue, and @marmbrus for review.