### PR TITLE
Simplify use of transactions when performing overwrites and when creating new tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,17 +350,15 @@ must also set a distribution key with the <tt>distkey</tt> option.
     </td>
  </tr>
  <tr>
-    <td><tt>usestagingtable</tt></td>
+    <td><del><tt>usestagingtable</tt></del> (Deprecated)</td>
     <td>No</td>
     <td><tt>true</tt></td>
     <td>
-<p>When performing an overwrite of existing data, this setting can be used to stage the new data in a temporary
-table, such that we make sure the <tt>COPY</tt> finishes successfully before making any changes to the existing table.
-This means that we minimize the amount of time that the target table will be unavailable and restore the old
-data should the <tt>COPY</tt> fail.</p>
+    <p>
+    Setting this deprecated option to <tt>false</tt> will cause an overwrite operation's destination table to be dropped immediately at the beginning of the write, making the overwrite operation non-atomic and reducing the availability of the destination table. This may reduce the temporary disk space requirements for overwrites.
+    </p>
 
-<p>You may wish to disable this by setting the parameter to <tt>false</tt> if you can't spare the disk space in your
-Redshift cluster and/or don't have requirements to keep the table availability high.</p>
+    <p>Since setting <tt>usestagingtable=false</tt> operation risks data loss / unavailability, we have chosen to deprecate it in favor of requiring users to manually drop the destination table themselves.</p>
     </td>
  </tr>
  <tr>
@@ -480,7 +478,7 @@ When reading from / writing to Redshift, this library reads and writes data in S
 
 **Overwriting an existing table**: By default, this library uses transactions to perform overwrites, which are implemented by deleting the destination table, creating a new empty table, and appending rows to it.
 
-If `usestagingtable` is set to `false` then this library will commit the `DELETE TABLE` command before appending rows to the new table, sacrificing the atomicity of the overwrite operation but reducing the amount of staging space that Redshift needs during the overwrite.
+If the deprecated `usestagingtable` setting is set to `false` then this library will commit the `DELETE TABLE` command before appending rows to the new table, sacrificing the atomicity of the overwrite operation but reducing the amount of staging space that Redshift needs during the overwrite.
 
 **Querying Redshift tables**: Queries use Redshift's [`UNLOAD`](https://docs.aws.amazon.com/redshift/latest/dg/r_UNLOAD.html) command to execute a query and save its results to S3 and use [manifests](https://docs.aws.amazon.com/redshift/latest/dg/loading-data-files-using-manifest.html) to guard against certain eventually-consistent S3 operations. As a result, queries from Redshift data source for Spark should have the same consistency properties as regular Redshift queries.
 

--- a/src/main/scala/com/databricks/spark/redshift/Parameters.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Parameters.scala
@@ -191,6 +191,8 @@ private[redshift] object Parameters {
     def sortKeySpec: Option[String] = parameters.get("sortkeyspec")
 
     /**
+     * DEPRECATED: see PR #157.
+     *
      * When true, data is always loaded into a new temporary table when performing an overwrite.
      * This is to ensure that the whole load process succeeds before dropping any data from
      * Redshift, which can be useful if, in the event of failures, stale data is better than no data

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
@@ -328,6 +328,12 @@ private[redshift] class RedshiftWriter(
         "For save operations you must specify a Redshift table name with the 'dbtable' parameter")
     }
 
+    if (!params.useStagingTable) {
+      log.warn("Setting useStagingTable=false is deprecated; instead, we recommend that you " +
+        "drop the target table yourself. For more details on this deprecation, see" +
+        "https://github.com/databricks/spark-redshift/pull/157")
+    }
+
     val creds: AWSCredentials =
       AWSCredentialsUtils.load(params, sqlContext.sparkContext.hadoopConfiguration)
 

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
@@ -141,6 +141,8 @@ private[redshift] class RedshiftWriter(
         jdbcWrapper.executeInterruptibly(conn.prepareStatement(copyStatement))
       } catch {
         case e: SQLException =>
+          log.error("SQLException thrown while running COPY query; will attempt to retrieve " +
+            "more information by querying the STL_LOAD_ERRORS table", e)
           // Try to query Redshift's STL_LOAD_ERRORS table to figure out why the load failed.
           // See http://docs.aws.amazon.com/redshift/latest/dg/r_STL_LOAD_ERRORS.html for details.
           conn.rollback()
@@ -356,6 +358,7 @@ private[redshift] class RedshiftWriter(
     } catch {
       case NonFatal(e) =>
         try {
+          log.error("Exception thrown during Redshift load; will roll back transaction", e)
           conn.rollback()
         } catch {
           case NonFatal(e2) =>

--- a/src/test/scala/com/databricks/spark/redshift/MockRedshift.scala
+++ b/src/test/scala/com/databricks/spark/redshift/MockRedshift.scala
@@ -89,6 +89,12 @@ class MockRedshift(
     }
   }
 
+  def verifyThatRollbackWasCalled(): Unit = {
+    jdbcConnections.foreach { conn =>
+      verify(conn, atLeastOnce()).rollback()
+    }
+  }
+
   def verifyThatCommitWasNotCalled(): Unit = {
     jdbcConnections.foreach { conn =>
       verify(conn, never()).commit()

--- a/src/test/scala/com/databricks/spark/redshift/MockRedshift.scala
+++ b/src/test/scala/com/databricks/spark/redshift/MockRedshift.scala
@@ -88,6 +88,12 @@ class MockRedshift(
     }
   }
 
+  def verifyThatCommitWasNotCalled(): Unit = {
+    jdbcConnections.foreach { conn =>
+      verify(conn, never()).commit()
+    }
+  }
+
   def verifyThatExpectedQueriesWereIssued(expectedQueries: Seq[Regex]): Unit = {
     expectedQueries.zip(queriesIssued).foreach { case (expected, actual) =>
       if (expected.findFirstMatchIn(actual).isEmpty) {

--- a/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
@@ -266,19 +266,11 @@ class RedshiftSourceSuite
       "distkey" -> "testint")
 
     val expectedCommands = Seq(
-      "DROP TABLE IF EXISTS \"PUBLIC\"\\.\"test_table_staging_.*\"".r,
-      ("CREATE TABLE IF NOT EXISTS \"PUBLIC\"\\.\"test_table_staging.*" +
+      "DROP TABLE IF EXISTS \"PUBLIC\"\\.\"test_table.*\"".r,
+      ("CREATE TABLE IF NOT EXISTS \"PUBLIC\"\\.\"test_table.*" +
         " DISTSTYLE KEY DISTKEY \\(testint\\).*").r,
-      "COPY \"PUBLIC\"\\.\"test_table_staging_.*\"".r,
-      "GRANT SELECT ON \"PUBLIC\"\\.\"test_table_staging.+\" TO jeremy".r,
-      """
-        | BEGIN;
-        | ALTER TABLE "PUBLIC"\."test_table" RENAME TO "test_table_backup_.*";
-        | ALTER TABLE "PUBLIC"\."test_table_staging_.*" RENAME TO "test_table";
-        | DROP TABLE "PUBLIC"\."test_table_backup_.*";
-        | END;
-      """.stripMargin.trim.r,
-      "DROP TABLE IF EXISTS \"PUBLIC\"\\.\"test_table_staging_.*\"".r)
+      "COPY \"PUBLIC\"\\.\"test_table.*\"".r,
+      "GRANT SELECT ON \"PUBLIC\"\\.\"test_table\" TO jeremy".r)
 
     val mockRedshift = new MockRedshift(
       defaultParams("url"),
@@ -316,6 +308,7 @@ class RedshiftSourceSuite
         testSqlContext, df, SaveMode.Append, Parameters.mergeParameters(defaultParams))
     }
     mockRedshift.verifyThatConnectionsWereClosed()
+    mockRedshift.verifyThatCommitWasNotCalled()
     mockRedshift.verifyThatExpectedQueriesWereIssued(Seq.empty)
   }
 
@@ -325,23 +318,21 @@ class RedshiftSourceSuite
     val mockRedshift = new MockRedshift(
       defaultParams("url"),
       Map(TableName.parseFromEscaped("test_table").toString -> TestUtils.testSchema),
-      jdbcQueriesThatShouldFail = Seq("COPY \"PUBLIC\".\"test_table_staging_.*\"".r))
+      jdbcQueriesThatShouldFail = Seq("COPY \"PUBLIC\".\"test_table.*\"".r))
 
     val expectedCommands = Seq(
-      "DROP TABLE IF EXISTS \"PUBLIC\".\"test_table_staging_.*\"".r,
-      "CREATE TABLE IF NOT EXISTS \"PUBLIC\".\"test_table_staging_.*\"".r,
-      "COPY \"PUBLIC\".\"test_table_staging_.*\"".r,
-      ".*FROM stl_load_errors.*".r,
-      "DROP TABLE IF EXISTS \"PUBLIC\".\"test_table_staging_.*\"".r
+      "DROP TABLE IF EXISTS \"PUBLIC\".\"test_table.*\"".r,
+      "CREATE TABLE IF NOT EXISTS \"PUBLIC\".\"test_table.*\"".r,
+      "COPY \"PUBLIC\".\"test_table.*\"".r,
+      ".*FROM stl_load_errors.*".r
     )
 
     val source = new DefaultSource(mockRedshift.jdbcWrapper, _ => mockS3Client)
     intercept[Exception] {
       source.createRelation(testSqlContext, SaveMode.Overwrite, params, expectedDataDF)
-      mockRedshift.verifyThatConnectionsWereClosed()
-      mockRedshift.verifyThatExpectedQueriesWereIssued(expectedCommands)
     }
     mockRedshift.verifyThatConnectionsWereClosed()
+    mockRedshift.verifyThatCommitWasNotCalled()
     mockRedshift.verifyThatExpectedQueriesWereIssued(expectedCommands)
   }
 

--- a/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
@@ -297,20 +297,12 @@ class RedshiftSourceSuite
       "usestagingtable" -> "true")
 
     val expectedCommands = Seq(
-      "DROP TABLE IF EXISTS \"PUBLIC\".\"test_table_staging_.*\"".r,
-      "CREATE TABLE IF NOT EXISTS \"PUBLIC\".\"test_table_staging_.*\"".r,
-      "DELETE FROM \"PUBLIC\".\"test_table_staging_.*\" WHERE id < 100".r,
-      "DELETE FROM \"PUBLIC\".\"test_table_staging_.*\" WHERE id > 100".r,
-      "DELETE FROM \"PUBLIC\".\"test_table_staging_.*\" WHERE id = -1".r,
-      "COPY \"PUBLIC\".\"test_table_staging_.*\"".r,
-      """
-        | BEGIN;
-        | ALTER TABLE "PUBLIC"\."test_table" RENAME TO "test_table_backup_.*";
-        | ALTER TABLE "PUBLIC"\."test_table_staging_.*" RENAME TO "test_table";
-        | DROP TABLE "PUBLIC"\."test_table_backup_.*";
-        | END;
-      """.stripMargin.trim.r,
-      "DROP TABLE IF EXISTS \"PUBLIC\"\\.\"test_table_staging_.*\"".r)
+      "DROP TABLE IF EXISTS \"PUBLIC\".\"test_table.*\"".r,
+      "CREATE TABLE IF NOT EXISTS \"PUBLIC\".\"test_table.*\"".r,
+      "DELETE FROM \"PUBLIC\".\"test_table.*\" WHERE id < 100".r,
+      "DELETE FROM \"PUBLIC\".\"test_table.*\" WHERE id > 100".r,
+      "DELETE FROM \"PUBLIC\".\"test_table.*\" WHERE id = -1".r,
+      "COPY \"PUBLIC\".\"test_table.*\"".r)
 
     source.createRelation(testSqlContext, SaveMode.Overwrite, params, expectedDataDF)
     mockRedshift.verifyThatExpectedQueriesWereIssued(expectedCommands)

--- a/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
@@ -359,6 +359,7 @@ class RedshiftSourceSuite
     }
     mockRedshift.verifyThatConnectionsWereClosed()
     mockRedshift.verifyThatCommitWasNotCalled()
+    mockRedshift.verifyThatRollbackWasCalled()
     mockRedshift.verifyThatExpectedQueriesWereIssued(Seq.empty)
   }
 
@@ -383,6 +384,7 @@ class RedshiftSourceSuite
     }
     mockRedshift.verifyThatConnectionsWereClosed()
     mockRedshift.verifyThatCommitWasNotCalled()
+    mockRedshift.verifyThatRollbackWasCalled()
     mockRedshift.verifyThatExpectedQueriesWereIssued(expectedCommands)
   }
 


### PR DESCRIPTION
This patch aims to significantly simplify our use of transactions when performing overwrites and when creating new tables; it addresses a few shortcomings in the existing code: previously, we didn't issue the `CREATE TABLE` and `COPY` commands as part of the same transaction when creating new tables and when performing overwrites we created a temporary table outside of a transaction, opening the possibility for that table to be leaked in rare corner-cases.

To address this, this patch refactors the main write logic so that it uses a JDBC connection with auto-commit disabled. Explicitly issuing `commit()` lets us significantly simplify the code and reduces duplication between the branches for handling different SaveModes.

One important change: previously, `usestagingtable` would literally create a separate staging table, but now we will simply delete the existing table and re-create it in a transaction; this frees us of the burden of having to find a unique name for the staging table. This should be safe due to Redshift's serializable snapshot isolation semantics. When `usestagingtable` is disabled, this now means that we simply issue an extra `commit()` after the original table's deletion so that the original table's resources are freed (which lets us write the new rows without having to maintain both the old and new tables at the same time).

/cc @jaley, who wrote the original staging-table-handling code; it would be good if you could confirm whether the changes here will undermine the performance benefits / semantics of the old `usestagingtable=false` path.

Fixes #153 and #154.