### PR TITLE
Have AWSCredentialsUtils.load() perform the check for STS credentials

### DIFF
--- a/src/main/scala/com/databricks/spark/redshift/AWSCredentialsUtils.scala
+++ b/src/main/scala/com/databricks/spark/redshift/AWSCredentialsUtils.scala
@@ -21,6 +21,8 @@ import java.net.URI
 import com.amazonaws.auth.{BasicAWSCredentials, AWSCredentials, AWSSessionCredentials, InstanceProfileCredentialsProvider}
 import org.apache.hadoop.conf.Configuration
 
+import com.databricks.spark.redshift.Parameters.MergedParameters
+
 private[redshift] object AWSCredentialsUtils {
 
   /**
@@ -37,7 +39,11 @@ private[redshift] object AWSCredentialsUtils {
     }
   }
 
-  def load(tempPath: String, hadoopConfiguration: Configuration): AWSCredentials = {
+  def load(params: MergedParameters, hadoopConfiguration: Configuration): AWSCredentials = {
+    params.temporaryAWSCredentials.getOrElse(loadFromURI(params.rootTempDir, hadoopConfiguration))
+  }
+
+  def loadFromURI(tempPath: String, hadoopConfiguration: Configuration): AWSCredentials = {
     // scalastyle:off
     // A good reference on Hadoop's configuration loading / precedence is
     // https://github.com/apache/hadoop/blob/trunk/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md

--- a/src/main/scala/com/databricks/spark/redshift/AWSCredentialsUtils.scala
+++ b/src/main/scala/com/databricks/spark/redshift/AWSCredentialsUtils.scala
@@ -43,7 +43,7 @@ private[redshift] object AWSCredentialsUtils {
     params.temporaryAWSCredentials.getOrElse(loadFromURI(params.rootTempDir, hadoopConfiguration))
   }
 
-  def loadFromURI(tempPath: String, hadoopConfiguration: Configuration): AWSCredentials = {
+  private def loadFromURI(tempPath: String, hadoopConfiguration: Configuration): AWSCredentials = {
     // scalastyle:off
     // A good reference on Hadoop's configuration loading / precedence is
     // https://github.com/apache/hadoop/blob/trunk/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
@@ -20,7 +20,6 @@ import java.net.URI
 
 import com.amazonaws.auth.AWSCredentials
 import com.amazonaws.services.s3.AmazonS3Client
-import org.apache.hadoop.conf.Configuration
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types._
@@ -85,8 +84,7 @@ private[redshift] case class RedshiftRelation(
   }
 
   override def buildScan(requiredColumns: Array[String], filters: Array[Filter]): RDD[Row] = {
-    val creds =
-      AWSCredentialsUtils.load(params.rootTempDir, sqlContext.sparkContext.hadoopConfiguration)
+    val creds = AWSCredentialsUtils.load(params, sqlContext.sparkContext.hadoopConfiguration)
     Utils.checkThatBucketHasObjectLifecycleConfiguration(params.rootTempDir, s3ClientFactory(creds))
     if (requiredColumns.isEmpty) {
       // In the special case where no columns were requested, issue a `count(*)` against Redshift
@@ -141,8 +139,7 @@ private[redshift] case class RedshiftRelation(
     // Always quote column names:
     val columnList = requiredColumns.map(col => s""""$col"""").mkString(", ")
     val whereClause = FilterPushdown.buildWhereClause(schema, filters)
-    val creds = params.temporaryAWSCredentials.getOrElse(
-      AWSCredentialsUtils.load(params.rootTempDir, sqlContext.sparkContext.hadoopConfiguration))
+    val creds = AWSCredentialsUtils.load(params, sqlContext.sparkContext.hadoopConfiguration)
     val credsString: String = AWSCredentialsUtils.getRedshiftCredentialsString(creds)
     val query = {
       // Since the query passed to UNLOAD will be enclosed in single quotes, we need to escape

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
@@ -352,8 +352,8 @@ private[redshift] class RedshiftWriter(
         "For save operations you must specify a Redshift table name with the 'dbtable' parameter")
     }
 
-    val creds: AWSCredentials = params.temporaryAWSCredentials.getOrElse(
-      AWSCredentialsUtils.load(params.rootTempDir, sqlContext.sparkContext.hadoopConfiguration))
+    val creds: AWSCredentials =
+      AWSCredentialsUtils.load(params, sqlContext.sparkContext.hadoopConfiguration)
 
     Utils.assertThatFileSystemIsNotS3BlockFileSystem(
       new URI(params.rootTempDir), sqlContext.sparkContext.hadoopConfiguration)

--- a/src/test/scala/com/databricks/spark/redshift/AWSCredentialsUtilsSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/AWSCredentialsUtilsSuite.scala
@@ -34,67 +34,67 @@ class AWSCredentialsUtilsSuite extends FunSuite {
       "aws_access_key_id=ACCESSKEYID;aws_secret_access_key=SECRET/KEY;token=SESSION/Token")
   }
 
-  test("AWSCredentials.load() credentials precedence for s3:// URIs") {
+  test("AWSCredentials.loadFromURI() credentials precedence for s3:// URIs") {
     val conf = new Configuration(false)
     conf.set("fs.s3.awsAccessKeyId", "CONFID")
     conf.set("fs.s3.awsSecretAccessKey", "CONFKEY")
 
     {
-      val creds = AWSCredentialsUtils.load("s3://URIID:URIKEY@bucket/path", conf)
+      val creds = AWSCredentialsUtils.loadFromURI("s3://URIID:URIKEY@bucket/path", conf)
       assert(creds.getAWSAccessKeyId === "URIID")
       assert(creds.getAWSSecretKey === "URIKEY")
     }
 
     {
-      val creds = AWSCredentialsUtils.load("s3://bucket/path", conf)
+      val creds = AWSCredentialsUtils.loadFromURI("s3://bucket/path", conf)
       assert(creds.getAWSAccessKeyId === "CONFID")
       assert(creds.getAWSSecretKey === "CONFKEY")
     }
 
     // The s3:// protocol does not work with EC2 IAM instance profiles.
     val e = intercept[IllegalArgumentException] {
-      AWSCredentialsUtils.load("s3://bucket/path", new Configuration(false))
+      AWSCredentialsUtils.loadFromURI("s3://bucket/path", new Configuration(false))
     }
     assert(e.getMessage.contains("Key must be specified"))
   }
 
-  test("AWSCredentials.load() credentials precedence for s3n:// URIs") {
+  test("AWSCredentials.loadFromURI() credentials precedence for s3n:// URIs") {
     val conf = new Configuration(false)
     conf.set("fs.s3n.awsAccessKeyId", "CONFID")
     conf.set("fs.s3n.awsSecretAccessKey", "CONFKEY")
 
     {
-      val creds = AWSCredentialsUtils.load("s3n://URIID:URIKEY@bucket/path", conf)
+      val creds = AWSCredentialsUtils.loadFromURI("s3n://URIID:URIKEY@bucket/path", conf)
       assert(creds.getAWSAccessKeyId === "URIID")
       assert(creds.getAWSSecretKey === "URIKEY")
     }
 
     {
-      val creds = AWSCredentialsUtils.load("s3n://bucket/path", conf)
+      val creds = AWSCredentialsUtils.loadFromURI("s3n://bucket/path", conf)
       assert(creds.getAWSAccessKeyId === "CONFID")
       assert(creds.getAWSSecretKey === "CONFKEY")
     }
 
     // The s3n:// protocol does not work with EC2 IAM instance profiles.
     val e = intercept[IllegalArgumentException] {
-      AWSCredentialsUtils.load("s3n://bucket/path", new Configuration(false))
+      AWSCredentialsUtils.loadFromURI("s3n://bucket/path", new Configuration(false))
     }
     assert(e.getMessage.contains("Key must be specified"))
   }
 
-  test("AWSCredentials.load() credentials precedence for s3a:// URIs") {
+  test("AWSCredentials.loadFromURI() credentials precedence for s3a:// URIs") {
     val conf = new Configuration(false)
     conf.set("fs.s3a.access.key", "CONFID")
     conf.set("fs.s3a.secret.key", "CONFKEY")
 
     {
-      val creds = AWSCredentialsUtils.load("s3a://URIID:URIKEY@bucket/path", conf)
+      val creds = AWSCredentialsUtils.loadFromURI("s3a://URIID:URIKEY@bucket/path", conf)
       assert(creds.getAWSAccessKeyId === "URIID")
       assert(creds.getAWSSecretKey === "URIKEY")
     }
 
     {
-      val creds = AWSCredentialsUtils.load("s3a://bucket/path", conf)
+      val creds = AWSCredentialsUtils.loadFromURI("s3a://bucket/path", conf)
       assert(creds.getAWSAccessKeyId === "CONFID")
       assert(creds.getAWSSecretKey === "CONFKEY")
     }
@@ -104,7 +104,7 @@ class AWSCredentialsUtilsSuite extends FunSuite {
     // just check that this test fails because the AWS client fails to obtain those credentials.
     // TODO: refactor and mock to enable proper tests here.
     val e = intercept[AmazonClientException] {
-      AWSCredentialsUtils.load("s3a://bucket/path", new Configuration(false))
+      AWSCredentialsUtils.loadFromURI("s3a://bucket/path", new Configuration(false))
     }
     assert(e.getMessage === "Unable to load credentials from Amazon EC2 metadata service" ||
       e.getMessage.contains("The requested metadata is not found at"))

--- a/src/test/scala/com/databricks/spark/redshift/AWSCredentialsUtilsSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/AWSCredentialsUtilsSuite.scala
@@ -16,12 +16,21 @@
 
 package com.databricks.spark.redshift
 
+import scala.language.implicitConversions
+
 import com.amazonaws.AmazonClientException
 import com.amazonaws.auth.{BasicSessionCredentials, BasicAWSCredentials}
 import org.apache.hadoop.conf.Configuration
 import org.scalatest.FunSuite
 
+import com.databricks.spark.redshift.Parameters.MergedParameters
+
 class AWSCredentialsUtilsSuite extends FunSuite {
+
+  private implicit def string2Params(tempdir: String): MergedParameters = {
+    MergedParameters.apply(Map("tempdir" -> tempdir))
+  }
+
   test("credentialsString with regular keys") {
     val creds = new BasicAWSCredentials("ACCESSKEYID", "SECRET/KEY/WITH/SLASHES")
     assert(AWSCredentialsUtils.getRedshiftCredentialsString(creds) ===
@@ -34,67 +43,67 @@ class AWSCredentialsUtilsSuite extends FunSuite {
       "aws_access_key_id=ACCESSKEYID;aws_secret_access_key=SECRET/KEY;token=SESSION/Token")
   }
 
-  test("AWSCredentials.loadFromURI() credentials precedence for s3:// URIs") {
+  test("AWSCredentials.load() credentials precedence for s3:// URIs") {
     val conf = new Configuration(false)
     conf.set("fs.s3.awsAccessKeyId", "CONFID")
     conf.set("fs.s3.awsSecretAccessKey", "CONFKEY")
 
     {
-      val creds = AWSCredentialsUtils.loadFromURI("s3://URIID:URIKEY@bucket/path", conf)
+      val creds = AWSCredentialsUtils.load("s3://URIID:URIKEY@bucket/path", conf)
       assert(creds.getAWSAccessKeyId === "URIID")
       assert(creds.getAWSSecretKey === "URIKEY")
     }
 
     {
-      val creds = AWSCredentialsUtils.loadFromURI("s3://bucket/path", conf)
+      val creds = AWSCredentialsUtils.load("s3://bucket/path", conf)
       assert(creds.getAWSAccessKeyId === "CONFID")
       assert(creds.getAWSSecretKey === "CONFKEY")
     }
 
     // The s3:// protocol does not work with EC2 IAM instance profiles.
     val e = intercept[IllegalArgumentException] {
-      AWSCredentialsUtils.loadFromURI("s3://bucket/path", new Configuration(false))
+      AWSCredentialsUtils.load("s3://bucket/path", new Configuration(false))
     }
     assert(e.getMessage.contains("Key must be specified"))
   }
 
-  test("AWSCredentials.loadFromURI() credentials precedence for s3n:// URIs") {
+  test("AWSCredentials.load() credentials precedence for s3n:// URIs") {
     val conf = new Configuration(false)
     conf.set("fs.s3n.awsAccessKeyId", "CONFID")
     conf.set("fs.s3n.awsSecretAccessKey", "CONFKEY")
 
     {
-      val creds = AWSCredentialsUtils.loadFromURI("s3n://URIID:URIKEY@bucket/path", conf)
+      val creds = AWSCredentialsUtils.load("s3n://URIID:URIKEY@bucket/path", conf)
       assert(creds.getAWSAccessKeyId === "URIID")
       assert(creds.getAWSSecretKey === "URIKEY")
     }
 
     {
-      val creds = AWSCredentialsUtils.loadFromURI("s3n://bucket/path", conf)
+      val creds = AWSCredentialsUtils.load("s3n://bucket/path", conf)
       assert(creds.getAWSAccessKeyId === "CONFID")
       assert(creds.getAWSSecretKey === "CONFKEY")
     }
 
     // The s3n:// protocol does not work with EC2 IAM instance profiles.
     val e = intercept[IllegalArgumentException] {
-      AWSCredentialsUtils.loadFromURI("s3n://bucket/path", new Configuration(false))
+      AWSCredentialsUtils.load("s3n://bucket/path", new Configuration(false))
     }
     assert(e.getMessage.contains("Key must be specified"))
   }
 
-  test("AWSCredentials.loadFromURI() credentials precedence for s3a:// URIs") {
+  test("AWSCredentials.load() credentials precedence for s3a:// URIs") {
     val conf = new Configuration(false)
     conf.set("fs.s3a.access.key", "CONFID")
     conf.set("fs.s3a.secret.key", "CONFKEY")
 
     {
-      val creds = AWSCredentialsUtils.loadFromURI("s3a://URIID:URIKEY@bucket/path", conf)
+      val creds = AWSCredentialsUtils.load("s3a://URIID:URIKEY@bucket/path", conf)
       assert(creds.getAWSAccessKeyId === "URIID")
       assert(creds.getAWSSecretKey === "URIKEY")
     }
 
     {
-      val creds = AWSCredentialsUtils.loadFromURI("s3a://bucket/path", conf)
+      val creds = AWSCredentialsUtils.load("s3a://bucket/path", conf)
       assert(creds.getAWSAccessKeyId === "CONFID")
       assert(creds.getAWSSecretKey === "CONFKEY")
     }
@@ -104,7 +113,7 @@ class AWSCredentialsUtilsSuite extends FunSuite {
     // just check that this test fails because the AWS client fails to obtain those credentials.
     // TODO: refactor and mock to enable proper tests here.
     val e = intercept[AmazonClientException] {
-      AWSCredentialsUtils.loadFromURI("s3a://bucket/path", new Configuration(false))
+      AWSCredentialsUtils.load("s3a://bucket/path", new Configuration(false))
     }
     assert(e.getMessage === "Unable to load credentials from Amazon EC2 metadata service" ||
       e.getMessage.contains("The requested metadata is not found at"))


### PR DESCRIPTION
This patch moves the check for STS credentials into the `AWSCredentials.load()` call itself. The motivation for this is a single call-site where we forgot to do a `.getOrElse()`, which caused the STS credentials to be ignored. This broke `spark-redshift` for users who authenticated to AWS only via IAM instance profiles.