### PR TITLE
Allow Redshift user and password to be passed as options

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ The parameter map or <tt>OPTIONS</tt> provided in Spark SQL supports the followi
     <td><tt>password</tt></td>
     <td>No</td>
     <td>No default</td>
-    <td>The Redshift password.  Must be used in tandem with <tt>user</tt> option.  May only be used if the user and password are not passed in the URL, passing both will result in an error.</td>
+    <td>The Redshift password.  Must be used in tandem with <tt>user</tt> option.  May only be used if the user and password are not passed in the URL; passing both will result in an error.</td>
  </tr>
  <tr>
     <td><tt>url</tt></td>

--- a/README.md
+++ b/README.md
@@ -220,6 +220,18 @@ The parameter map or <tt>OPTIONS</tt> provided in Spark SQL supports the followi
     <td>The query to read from in Redshift</td>
  </tr>
  <tr>
+    <td><tt>user</tt></td>
+    <td>No</td>
+    <td>No default</td>
+    <td>The Redshift username.  Must be used in tandem with <tt>password</tt> option.  May only be used if the user and password are not passed in the URL, passing both will result in an error.</td>
+ </tr>
+ <tr>
+    <td><tt>password</tt></td>
+    <td>No</td>
+    <td>No default</td>
+    <td>The Redshift password.  Must be used in tandem with <tt>user</tt> option.  May only be used if the user and password are not passed in the URL, passing both will result in an error.</td>
+ </tr>
+ <tr>
     <td><tt>url</tt></td>
     <td>Yes</td>
     <td>No default</td>
@@ -227,8 +239,8 @@ The parameter map or <tt>OPTIONS</tt> provided in Spark SQL supports the followi
 <p>A JDBC URL, of the format, <tt>jdbc:subprotocol://host:port/database?user=username&password=password</tt></p>
 
 <ul>
- <li><tt>subprotocol</tt> can be <tt>postgresql</tt> or <tt>redshift</tt>, depending on which JDBC driver 
-    you have loaded. Note however that one Redshift-compatible driver must be on the classpath and match 
+ <li><tt>subprotocol</tt> can be <tt>postgresql</tt> or <tt>redshift</tt>, depending on which JDBC driver
+    you have loaded. Note however that one Redshift-compatible driver must be on the classpath and match
     this URL.</li>
  <li><tt>host</tt> and <tt>port</tt> should point to the Redshift master node, so security groups and/or VPC will
 need to be configured to allow access from your driver application.

--- a/src/it/scala/com/databricks/spark/redshift/CredentialsInUriIntegrationSuite.scala
+++ b/src/it/scala/com/databricks/spark/redshift/CredentialsInUriIntegrationSuite.scala
@@ -46,7 +46,7 @@ class CredentialsInUriIntegrationSuite extends IntegrationSuiteBase {
     assert(tempDir.contains("AKIA"), "tempdir did not contain AWS credentials")
     assert(!AWS_SECRET_ACCESS_KEY.contains("/"), "AWS secret key should not contain slash")
     sc = new SparkContext("local", getClass.getSimpleName)
-    conn = DefaultJDBCWrapper.getConnector(None, jdbcUrl)
+    conn = DefaultJDBCWrapper.getConnector(None, jdbcUrl, None)
   }
 
   test("roundtrip save and load") {

--- a/src/it/scala/com/databricks/spark/redshift/IntegrationSuiteBase.scala
+++ b/src/it/scala/com/databricks/spark/redshift/IntegrationSuiteBase.scala
@@ -88,7 +88,7 @@ trait IntegrationSuiteBase
     sc.hadoopConfiguration.setBoolean("fs.s3n.impl.disable.cache", true)
     sc.hadoopConfiguration.set("fs.s3n.awsAccessKeyId", AWS_ACCESS_KEY_ID)
     sc.hadoopConfiguration.set("fs.s3n.awsSecretAccessKey", AWS_SECRET_ACCESS_KEY)
-    conn = DefaultJDBCWrapper.getConnector(None, jdbcUrl)
+    conn = DefaultJDBCWrapper.getConnector(None, jdbcUrl, None)
   }
 
   override def afterAll(): Unit = {

--- a/src/it/scala/com/databricks/spark/redshift/PostgresDriverIntegrationSuite.scala
+++ b/src/it/scala/com/databricks/spark/redshift/PostgresDriverIntegrationSuite.scala
@@ -29,7 +29,7 @@ class PostgresDriverIntegrationSuite extends IntegrationSuiteBase {
   }
 
   test("postgresql driver takes precedence for jdbc:postgresql:// URIs") {
-    val conn = DefaultJDBCWrapper.getConnector(None, jdbcUrl)
+    val conn = DefaultJDBCWrapper.getConnector(None, jdbcUrl, None)
     try {
       assert(conn.getClass.getName === "org.postgresql.jdbc4.Jdbc4Connection")
     } finally {

--- a/src/main/scala/com/databricks/spark/redshift/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/redshift/DefaultSource.scala
@@ -75,7 +75,7 @@ class DefaultSource(jdbcWrapper: JDBCWrapper, s3ClientFactory: AWSCredentials =>
     }
 
     def tableExists: Boolean = {
-      val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl)
+      val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl, params.credentials)
       try {
         jdbcWrapper.tableExists(conn, table.toString)
       } finally {

--- a/src/main/scala/com/databricks/spark/redshift/Parameters.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Parameters.scala
@@ -56,6 +56,14 @@ private[redshift] object Parameters {
       throw new IllegalArgumentException(
         "You cannot specify both the 'dbtable' and 'query' parameters at the same time.")
     }
+    if (userParameters.contains("user") || userParameters.contains("password")) {
+      userParameters.get("url")
+        .filter (url => url.contains("user=") || url.contains("password="))
+        .foreach { _ =>
+          throw new IllegalArgumentException(
+            "You cannot specify credential in both the url and as options")
+        }
+    }
 
     MergedParameters(DEFAULT_PARAMETERS ++ userParameters)
   }
@@ -111,7 +119,7 @@ private[redshift] object Parameters {
         password <- parameters.get("password")
       ) yield (user, password)
     }
-    
+
     /**
      * A JDBC URL, of the format:
      *

--- a/src/main/scala/com/databricks/spark/redshift/Parameters.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Parameters.scala
@@ -63,7 +63,7 @@ private[redshift] object Parameters {
         throw new IllegalArgumentException(
           "You cannot specify credentials in both the URL and as user/password options")
         }
-    } else if(credsInURL.isEmpty) {
+    } else if (credsInURL.isEmpty) {
       throw new IllegalArgumentException(
         "You must specify credentials in either the URL or as user/password options")
     }

--- a/src/main/scala/com/databricks/spark/redshift/Parameters.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Parameters.scala
@@ -103,6 +103,16 @@ private[redshift] object Parameters {
     }
 
     /**
+    * User and password to be used to authenticate to Redshift
+    */
+    def credentials: Option[(String, String)] = {
+      for (
+        user <- parameters.get("user");
+        password <- parameters.get("password")
+      ) yield (user, password)
+    }
+    
+    /**
      * A JDBC URL, of the format:
      *
      *    jdbc:subprotocol://host:port/database?user=username&password=password

--- a/src/main/scala/com/databricks/spark/redshift/Parameters.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Parameters.scala
@@ -56,13 +56,18 @@ private[redshift] object Parameters {
       throw new IllegalArgumentException(
         "You cannot specify both the 'dbtable' and 'query' parameters at the same time.")
     }
+    val credsInURL = userParameters.get("url")
+      .filter (url => url.contains("user=") || url.contains("password="))
     if (userParameters.contains("user") || userParameters.contains("password")) {
-      userParameters.get("url")
-        .filter (url => url.contains("user=") || url.contains("password="))
-        .foreach { _ =>
+        credsInURL.foreach { _ =>
           throw new IllegalArgumentException(
-            "You cannot specify credential in both the url and as options")
+            "You cannot specify credentials in both the URL and as user/password options")
         }
+    } else {
+      if(credsInURL.isEmpty) {
+        throw new IllegalArgumentException(
+          "You must specify credentials in either the URL or as user/password options")
+      }
     }
 
     MergedParameters(DEFAULT_PARAMETERS ++ userParameters)

--- a/src/main/scala/com/databricks/spark/redshift/Parameters.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Parameters.scala
@@ -57,17 +57,15 @@ private[redshift] object Parameters {
         "You cannot specify both the 'dbtable' and 'query' parameters at the same time.")
     }
     val credsInURL = userParameters.get("url")
-      .filter (url => url.contains("user=") || url.contains("password="))
+      .filter(url => url.contains("user=") || url.contains("password="))
     if (userParameters.contains("user") || userParameters.contains("password")) {
-        credsInURL.foreach { _ =>
-          throw new IllegalArgumentException(
-            "You cannot specify credentials in both the URL and as user/password options")
-        }
-    } else {
-      if(credsInURL.isEmpty) {
+      if (credsInURL.isDefined) {
         throw new IllegalArgumentException(
-          "You must specify credentials in either the URL or as user/password options")
-      }
+          "You cannot specify credentials in both the URL and as user/password options")
+        }
+    } else if(credsInURL.isEmpty) {
+      throw new IllegalArgumentException(
+        "You must specify credentials in either the URL or as user/password options")
     }
 
     MergedParameters(DEFAULT_PARAMETERS ++ userParameters)

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftJDBCWrapper.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftJDBCWrapper.scala
@@ -231,6 +231,7 @@ private[redshift] class JDBCWrapper {
         properties.setProperty("user", user)
         properties.setProperty("password", password)
       }
+      case None =>
     }
     driver.connect(url, properties)
   }

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftJDBCWrapper.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftJDBCWrapper.scala
@@ -226,12 +226,10 @@ private[redshift] class JDBCWrapper {
       throw new IllegalArgumentException(s"Did not find registered driver with class $driverClass")
     }
     val properties = new Properties()
-    credentials match {
-      case Some((user, password)) => {
+    credentials.foreach { case(user, password) => {
         properties.setProperty("user", user)
         properties.setProperty("password", password)
       }
-      case None =>
     }
     driver.connect(url, properties)
   }

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftJDBCWrapper.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftJDBCWrapper.scala
@@ -197,7 +197,10 @@ private[redshift] class JDBCWrapper {
    *                                discover the appropriate driver class.
    * @param url the JDBC url to connect to.
    */
-  def getConnector(userProvidedDriverClass: Option[String], url: String, credentials: Option[(String, String)] = None): Connection = {
+  def getConnector(
+      userProvidedDriverClass: Option[String],
+      url: String,
+      credentials: Option[(String, String)]) : Connection = {
     val subprotocol = url.stripPrefix("jdbc:").split(":")(0)
     val driverClass: String = getDriverClass(subprotocol, userProvidedDriverClass)
     registerDriver(driverClass)
@@ -225,9 +228,6 @@ private[redshift] class JDBCWrapper {
     val properties = new Properties()
     credentials match {
       case Some((user, password)) => {
-        if (url.contains("user=") || url.contains("password=")) {
-          throw new IllegalArgumentException(s"Ambiguous Credentials: User and password must be passed as options or within the URL, not both")
-        }
         properties.setProperty("user", user)
         properties.setProperty("password", password)
       }

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
@@ -55,7 +55,7 @@ private[redshift] case class RedshiftRelation(
     userSchema.getOrElse {
       val tableNameOrSubquery =
         params.query.map(q => s"($q)").orElse(params.table.map(_.toString)).get
-      val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl)
+      val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl, params.credentials)
       try {
         jdbcWrapper.resolveTable(conn, tableNameOrSubquery)
       } finally {
@@ -92,7 +92,7 @@ private[redshift] case class RedshiftRelation(
       val whereClause = FilterPushdown.buildWhereClause(schema, filters)
       val countQuery = s"SELECT count(*) FROM $tableNameOrSubquery $whereClause"
       log.info(countQuery)
-      val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl)
+      val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl, params.credentials)
       try {
         val results = jdbcWrapper.executeQueryInterruptibly(conn.prepareStatement(countQuery))
         if (results.next()) {
@@ -111,7 +111,7 @@ private[redshift] case class RedshiftRelation(
       val tempDir = params.createPerQueryTempDir()
       val unloadSql = buildUnloadStmt(requiredColumns, filters, tempDir)
       log.info(unloadSql)
-      val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl)
+      val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl, params.credentials)
       try {
         jdbcWrapper.executeInterruptibly(conn.prepareStatement(unloadSql))
       } finally {

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
@@ -360,7 +360,7 @@ private[redshift] class RedshiftWriter(
 
     Utils.checkThatBucketHasObjectLifecycleConfiguration(params.rootTempDir, s3ClientFactory(creds))
 
-    val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl)
+    val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl, params.credentials)
 
     try {
       val tempDir = params.createPerQueryTempDir()

--- a/src/test/scala/com/databricks/spark/redshift/MockRedshift.scala
+++ b/src/test/scala/com/databricks/spark/redshift/MockRedshift.scala
@@ -68,7 +68,8 @@ class MockRedshift(
 
   doAnswer(new Answer[Connection] {
       override def answer(invocation: InvocationOnMock): Connection = createMockConnection()
-    }).when(jdbcWrapper).getConnector(any[Option[String]](), same(jdbcUrl), any[Option[(String, String)]]())
+    }).when(jdbcWrapper)
+      .getConnector(any[Option[String]](), same(jdbcUrl), any[Option[(String, String)]]())
 
   doAnswer(new Answer[Boolean] {
     override def answer(invocation: InvocationOnMock): Boolean = {

--- a/src/test/scala/com/databricks/spark/redshift/MockRedshift.scala
+++ b/src/test/scala/com/databricks/spark/redshift/MockRedshift.scala
@@ -68,7 +68,7 @@ class MockRedshift(
 
   doAnswer(new Answer[Connection] {
       override def answer(invocation: InvocationOnMock): Connection = createMockConnection()
-    }).when(jdbcWrapper).getConnector(any[Option[String]](), same(jdbcUrl))
+    }).when(jdbcWrapper).getConnector(any[Option[String]](), same(jdbcUrl), any[Option[(String, String)]]())
 
   doAnswer(new Answer[Boolean] {
     override def answer(invocation: InvocationOnMock): Boolean = {

--- a/src/test/scala/com/databricks/spark/redshift/ParametersSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/ParametersSuite.scala
@@ -27,7 +27,7 @@ class ParametersSuite extends FunSuite with Matchers {
     val params = Map(
       "tempdir" -> "s3://foo/bar",
       "dbtable" -> "test_schema.test_table",
-      "url" -> "jdbc:redshift://foo/bar")
+      "url" -> "jdbc:redshift://foo/bar?user=user&password=password")
 
     val mergedParams = Parameters.mergeParameters(params)
 
@@ -46,7 +46,7 @@ class ParametersSuite extends FunSuite with Matchers {
     val params = Map(
       "tempdir" -> "s3://foo/bar",
       "dbtable" -> "test_table",
-      "url" -> "jdbc:redshift://foo/bar")
+      "url" -> "jdbc:redshift://foo/bar?user=user&password=password")
 
     val mergedParams = Parameters.mergeParameters(params)
 
@@ -60,8 +60,8 @@ class ParametersSuite extends FunSuite with Matchers {
       }
     }
 
-    checkMerge(Map("dbtable" -> "test_table", "url" -> "jdbc:redshift://foo/bar"))
-    checkMerge(Map("tempdir" -> "s3://foo/bar", "url" -> "jdbc:redshift://foo/bar"))
+    checkMerge(Map("dbtable" -> "test_table", "url" -> "jdbc:redshift://foo/bar?user=user&password=password"))
+    checkMerge(Map("tempdir" -> "s3://foo/bar", "url" -> "jdbc:redshift://foo/bar?user=user&password=password"))
     checkMerge(Map("dbtable" -> "test_table", "tempdir" -> "s3://foo/bar"))
   }
 
@@ -69,7 +69,7 @@ class ParametersSuite extends FunSuite with Matchers {
     intercept[IllegalArgumentException] {
       Parameters.mergeParameters(Map(
         "tempdir" -> "s3://foo/bar",
-        "url" -> "jdbc:redshift://foo/bar"))
+        "url" -> "jdbc:redshift://foo/bar?user=user&password=password"))
     }.getMessage should (include ("dbtable") and include ("query"))
 
     intercept[IllegalArgumentException] {
@@ -77,12 +77,35 @@ class ParametersSuite extends FunSuite with Matchers {
         "tempdir" -> "s3://foo/bar",
         "dbtable" -> "test_table",
         "query" -> "select * from test_table",
-        "url" -> "jdbc:redshift://foo/bar"))
+        "url" -> "jdbc:redshift://foo/bar?user=user&password=password"))
     }.getMessage should (include ("dbtable") and include ("query") and include("both"))
 
     Parameters.mergeParameters(Map(
       "tempdir" -> "s3://foo/bar",
       "query" -> "select * from test_table",
-      "url" -> "jdbc:redshift://foo/bar"))
+      "url" -> "jdbc:redshift://foo/bar?user=user&password=password"))
+  }
+
+  test("Must specify credentials in either URL or 'user' and 'password' parameters, but not both") {
+    intercept[IllegalArgumentException] {
+      Parameters.mergeParameters(Map(
+        "tempdir" -> "s3://foo/bar",
+        "query" -> "select * from test_table",
+        "url" -> "jdbc:redshift://foo/bar"))
+    }.getMessage should (include ("credentials"))
+
+    intercept[IllegalArgumentException] {
+      Parameters.mergeParameters(Map(
+        "tempdir" -> "s3://foo/bar",
+        "query" -> "select * from test_table",
+        "user" -> "user",
+        "password" -> "password",
+        "url" -> "jdbc:redshift://foo/bar?user=user&password=password"))
+    }.getMessage should (include ("credentials") and include("both"))
+
+    Parameters.mergeParameters(Map(
+      "tempdir" -> "s3://foo/bar",
+      "query" -> "select * from test_table",
+      "url" -> "jdbc:redshift://foo/bar?user=user&password=password"))
   }
 }

--- a/src/test/scala/com/databricks/spark/redshift/ParametersSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/ParametersSuite.scala
@@ -59,9 +59,9 @@ class ParametersSuite extends FunSuite with Matchers {
         Parameters.mergeParameters(params)
       }
     }
-
-    checkMerge(Map("dbtable" -> "test_table", "url" -> "jdbc:redshift://foo/bar?user=user&password=password"))
-    checkMerge(Map("tempdir" -> "s3://foo/bar", "url" -> "jdbc:redshift://foo/bar?user=user&password=password"))
+    val testURL = "jdbc:redshift://foo/bar?user=user&password=password"
+    checkMerge(Map("dbtable" -> "test_table", "url" -> testURL))
+    checkMerge(Map("tempdir" -> "s3://foo/bar", "url" -> testURL))
     checkMerge(Map("dbtable" -> "test_table", "tempdir" -> "s3://foo/bar"))
   }
 

--- a/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
@@ -83,7 +83,7 @@ class RedshiftSourceSuite
 
   // Parameters common to most tests. Some parameters are overridden in specific tests.
   private def defaultParams: Map[String, String] = Map(
-    "url" -> "jdbc:redshift://foo/bar",
+    "url" -> "jdbc:redshift://foo/bar?user=user&password=password",
     "tempdir" -> s3TempDir,
     "dbtable" -> "test_table")
 
@@ -412,7 +412,7 @@ class RedshiftSourceSuite
 
   test("Cannot save when 'query' parameter is specified instead of 'dbtable'") {
     val invalidParams = Map(
-      "url" -> "jdbc:redshift://foo/bar",
+      "url" -> "jdbc:redshift://foo/bar?user=user&password=password",
       "tempdir" -> s3TempDir,
       "query" -> "select * from test_table")
 


### PR DESCRIPTION
Per https://github.com/databricks/spark-redshift/issues/132, this PR adds user and password options.  If these options are present and the user/password are still in the URL, an exception is thrown with a clear error message.

Unit tests are still pending - maybe it's better to check for ambiguous parameters in the Parameter class instead, to make it easier to test?  Glad for any other feedback as well!