### PR TITLE
Update artifact coordinates in README to include _2.11 and _2.10 suffixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,17 @@ This library is more suited to ETL than interactive queries, since large amounts
 
 You may use this library in your applications with the following dependency information:
 
+**Scala 2.10**
 ```
 groupId: com.databricks
-artifactId: spark-redshift
+artifactId: spark-redshift_2.10
+version: 0.6.0
+```
+
+**Scala 2.11**
+```
+groupId: com.databricks
+artifactId: spark-redshift_2.11
 version: 0.6.0
 ```
 


### PR DESCRIPTION
The current coordinates do not point to an existing package. Copying from https://github.com/databricks/spark-csv/blob/master/README.md