### PR TITLE
Add CSV option

### DIFF
--- a/src/main/scala/com/databricks/spark/redshift/Parameters.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Parameters.scala
@@ -31,11 +31,15 @@ private[redshift] object Parameters {
     // * distkey has no default, but is optional unless using diststyle KEY
     // * jdbcdriver has no default, but is optional
 
+    "tempformat" -> "AVRO",
+    "csvnullstring" -> "@NULL@",
     "overwrite" -> "false",
     "diststyle" -> "EVEN",
     "usestagingtable" -> "true",
     "postactions" -> ";"
   )
+
+  val VALID_TEMP_FORMATS = Set("AVRO", "CSV", "CSV GZIP")
 
   /**
    * Merge user parameters with the defaults, preferring user parameters if specified
@@ -43,6 +47,11 @@ private[redshift] object Parameters {
   def mergeParameters(userParameters: Map[String, String]): MergedParameters = {
     if (!userParameters.contains("tempdir")) {
       throw new IllegalArgumentException("'tempdir' is required for all Redshift loads and saves")
+    }
+    if (userParameters.contains("tempformat") &&
+      !(VALID_TEMP_FORMATS contains userParameters("tempformat"))) {
+      throw new IllegalArgumentException(
+        s"""Invalid temp format: ${userParameters("tempformat")}""")
     }
     if (!userParameters.contains("url")) {
       throw new IllegalArgumentException("A JDBC URL must be provided with 'url' parameter")
@@ -71,6 +80,17 @@ private[redshift] object Parameters {
      * are available for S3.
      */
     def rootTempDir: String = parameters("tempdir")
+
+    /**
+      * The format in which to save temporary files in S3. Defaults to "AVRO", other allowed values
+      * are "CSV" and "CSV GZIP" for CSV and gzipped CSV respectively.
+      */
+    def tempFormat: String = parameters("tempformat")
+
+    /**
+      * The String value to write for nulls when using CSV.
+      */
+    def nullString: String = parameters("csvnullstring")
 
     /**
      * Creates a per-query subdirectory in the [[rootTempDir]], with a random UUID.

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
@@ -97,8 +97,12 @@ private[redshift] class RedshiftWriter(
       manifestUrl: String): String = {
     val credsString: String = AWSCredentialsUtils.getRedshiftCredentialsString(creds)
     val fixedUrl = Utils.fixS3Url(manifestUrl)
+    val format = params.tempFormat match {
+      case "AVRO" => "AVRO 'auto'"
+      case csv => csv + s" NULL AS '${params.nullString}'"
+    }
     s"COPY ${params.table.get} FROM '$fixedUrl' CREDENTIALS '$credsString' FORMAT AS " +
-      s"AVRO 'auto' manifest ${params.extraCopyOptions}"
+      s"${format} manifest ${params.extraCopyOptions}"
   }
 
   /**
@@ -164,6 +168,7 @@ private[redshift] class RedshiftWriter(
     manifestUrl.foreach { manifestUrl =>
       // Load the temporary data into the new file
       val copyStatement = copySql(data.sqlContext, params, creds, manifestUrl)
+      log.info(copyStatement.replaceFirst("CREDENTIALS +'[^']*'", "CREDENTIALS ''"))
       try {
         jdbcWrapper.executeInterruptibly(conn.prepareStatement(copyStatement))
       } catch {
@@ -228,7 +233,9 @@ private[redshift] class RedshiftWriter(
   private def unloadData(
       sqlContext: SQLContext,
       data: DataFrame,
-      tempDir: String): Option[String] = {
+      tempDir: String,
+      tempFormat: String,
+      nullString: String): Option[String] = {
     // spark-avro does not support Date types. In addition, it converts Timestamps into longs
     // (milliseconds since the Unix epoch). Redshift is capable of loading timestamps in
     // 'epochmillisecs' format but there's no equivalent format for dates. To work around this, we
@@ -296,10 +303,15 @@ private[redshift] class RedshiftWriter(
       }
     )
 
-    sqlContext.createDataFrame(convertedRows, convertedSchema)
-      .write
-      .format("com.databricks.spark.avro")
-      .save(tempDir)
+    val writer = sqlContext.createDataFrame(convertedRows, convertedSchema).write
+    (tempFormat match {
+      case "AVRO" => writer.format("com.databricks.spark.avro")
+      case "CSV" => writer.format("com.databricks.spark.csv")
+          .option("nullValue", nullString)
+      case "CSV GZIP" => writer.format("com.databricks.spark.csv")
+          .option("nullValue", nullString)
+          .option("codec", "org.apache.hadoop.io.compress.GzipCodec")
+    }).save(tempDir)
 
     if (nonEmptyPartitions.value.isEmpty) {
       None
@@ -308,12 +320,12 @@ private[redshift] class RedshiftWriter(
       // for a description of the manifest file format. The URLs in this manifest must be absolute
       // and complete.
 
-      // The saved filenames depend on the spark-avro version. In spark-avro 1.0.0, the write
+      // The saved filenames depend on the spark-avro/csv version. In spark-avro 1.0.0, the write
       // path uses SparkContext.saveAsHadoopFile(), which produces filenames of the form
       // part-XXXXX.avro. In spark-avro 2.0.0+, the partition filenames are of the form
-      // part-r-XXXXX-UUID.avro.
+      // part-r-XXXXX-UUID.avro. In spark-csv, the partition filenames are of the form part-XXXXX.
       val fs = FileSystem.get(URI.create(tempDir), sqlContext.sparkContext.hadoopConfiguration)
-      val partitionIdRegex = "^part-(?:r-)?(\\d+)[^\\d+].*$".r
+      val partitionIdRegex = "^part-(?:r-)?(\\d+)(?:[.-].*)?$".r
       val filesToLoad: Seq[String] = {
         val nonEmptyPartitionIds = nonEmptyPartitions.value.toSet
         fs.listStatus(new Path(tempDir)).map(_.getPath.getName).collect {
@@ -340,7 +352,7 @@ private[redshift] class RedshiftWriter(
   }
 
   /**
-   * Write a DataFrame to a Redshift table, using S3 and Avro serialization
+   * Write a DataFrame to a Redshift table, using S3 and Avro or CSV serialization
    */
   def saveToRedshift(
       sqlContext: SQLContext,
@@ -364,7 +376,7 @@ private[redshift] class RedshiftWriter(
 
     try {
       val tempDir = params.createPerQueryTempDir()
-      val manifestUrl = unloadData(sqlContext, data, tempDir)
+      val manifestUrl = unloadData(sqlContext, data, tempDir, params.tempFormat, params.nullString)
       if (saveMode == SaveMode.Overwrite && params.useStagingTable) {
         withStagingTable(conn, params.table.get, stagingTable => {
           val updatedParams = MergedParameters(params.parameters.updated("dbtable", stagingTable))


### PR DESCRIPTION
We've got to the stage where our jobs are big enough that Redshift loads are becoming a major bottleneck with its AVRO performance problems. We're hoping Amazon will fix them, but in the mean time we've started running with a modified spark-redshift to allow us to import via CSV (Redshift `COPY`s are running at least 5 times faster with this for us).
It's probably not a good idea to merge this in at the moment - I'm not sure how robust it is to different data types / unusual characters in strings etc., and it would at least need some tests and documentation. And hopefully Amazon will soon fix AVRO import making it unnecessary anyway. But I thought I'd share my changes in case they are useful to anyone else.