### PR TITLE
Add roundtrip test for specifying Redshift JDBC credentials in conf rather than URI

### DIFF
--- a/src/it/scala/com/databricks/spark/redshift/AWSCredentialsInUriIntegrationSuite.scala
+++ b/src/it/scala/com/databricks/spark/redshift/AWSCredentialsInUriIntegrationSuite.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
  * This suite performs basic integration tests where the AWS credentials have been
  * encoded into the tempdir URI rather than being set in the Hadoop configuration.
  */
-class CredentialsInUriIntegrationSuite extends IntegrationSuiteBase {
+class AWSCredentialsInUriIntegrationSuite extends IntegrationSuiteBase {
 
   override protected val tempDir: String = {
     val uri = new URI(AWS_S3_SCRATCH_SPACE + randomSuffix + "/")
@@ -52,6 +52,6 @@ class CredentialsInUriIntegrationSuite extends IntegrationSuiteBase {
   test("roundtrip save and load") {
     val df = sqlContext.createDataFrame(sc.parallelize(Seq(Row(1)), 1),
       StructType(StructField("foo", IntegerType) :: Nil))
-    testRoundtripSaveAndLoad(s"save_with_one_empty_partition_$randomSuffix", df)
+    testRoundtripSaveAndLoad(s"roundtrip_save_and_load_$randomSuffix", df)
   }
 }

--- a/src/it/scala/com/databricks/spark/redshift/RedshiftCredentialsInConfIntegrationSuite.scala
+++ b/src/it/scala/com/databricks/spark/redshift/RedshiftCredentialsInConfIntegrationSuite.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016 Databricks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.databricks.spark.redshift
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
+
+/**
+ * This suite performs basic integration tests where the Redshift credentials have been
+ * specified via `spark-redshift`'s configuration rather than as part of the JDBC URL.
+ */
+class RedshiftCredentialsInConfIntegrationSuite extends IntegrationSuiteBase {
+
+  test("roundtrip save and load") {
+    val df = sqlContext.createDataFrame(sc.parallelize(Seq(Row(1)), 1),
+      StructType(StructField("foo", IntegerType) :: Nil))
+    val tableName = s"roundtrip_save_and_load_$randomSuffix"
+    try {
+      df.write
+        .format("com.databricks.spark.redshift")
+        .option("url", AWS_REDSHIFT_JDBC_URL)
+        .option("user", AWS_REDSHIFT_USER)
+        .option("password", AWS_REDSHIFT_PASSWORD)
+        .option("dbtable", tableName)
+        .option("tempdir", tempDir)
+        .save()
+      assert(DefaultJDBCWrapper.tableExists(conn, tableName))
+      val loadedDf = sqlContext.read
+        .format("com.databricks.spark.redshift")
+        .option("url", AWS_REDSHIFT_JDBC_URL)
+        .option("user", AWS_REDSHIFT_USER)
+        .option("password", AWS_REDSHIFT_PASSWORD)
+        .option("dbtable", tableName)
+        .option("tempdir", tempDir)
+        .load()
+      assert(loadedDf.schema === df.schema)
+      checkAnswer(loadedDf, df.collect())
+    } finally {
+      conn.prepareStatement(s"drop table if exists $tableName").executeUpdate()
+      conn.commit()
+    }
+  }
+
+}


### PR DESCRIPTION
Followup to #162 to add a roundtrip test case in order to improve code coverage.