### PR TITLE
Log effective Redshift COPY statement

### DIFF
--- a/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
@@ -171,6 +171,7 @@ private[redshift] class RedshiftWriter(
     manifestUrl.foreach { manifestUrl =>
       // Load the temporary data into the new file
       val copyStatement = copySql(data.sqlContext, params, creds, manifestUrl)
+      log.info(copyStatement)
       try {
         jdbcWrapper.executeInterruptibly(conn.prepareStatement(copyStatement))
       } catch {


### PR DESCRIPTION
This seems like a useful log message because:

 - It's reassuring to see that params set via extracopyoptions are
   actually used.

 - Currently the last log message one can see while COPY executes is
   CREATE TABLE logged a few lines before. This is a little confusing as
   can be understood as CREATE TABLE statement taking a long time.

 - There is a symmetric log message for UNLOAD statement in
   RedshiftRelation.scala.