### PR TITLE
Specify extra unloadoptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,19 @@ for other options).</p>
 at the end of the command can be used, but that should cover most possible use cases.</p>
     </td>
  </tr>
+ <tr>
+    <td><tt>extraunloadoptions</tt></td>
+    <td>No</td>
+    <td>No Default</td>
+    <td>
+<p>A list extra unload options to append to the Redshift <tt>UNLOAD</tt> command when writing data to S3, e.g. <tt>DELIMITER</tt>
+or <TT>FIXEDWIDTH</tt> (see the <a href="http://docs.aws.amazon.com/redshift/latest/dg/r_UNLOAD.html#unload-parameters">Redshift docs</a>
+for other options). Parameters <tt>ESCAPE</tt> and <tt>MANIFEST</tt> are always append.</p>
+
+<p>Note that since these options are appended to the end of the <tt>UNLOAD</tt> command, only options that make sense
+at the end of the command can be used, but that should cover most possible use cases.</p>
+    </td>
+ </tr>
 </table>
 
 ## Additional configuration options

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
@@ -179,7 +179,12 @@ private[redshift] case class RedshiftRelation(
     // the credentials passed via `credsString`.
     val fixedUrl = Utils.fixS3Url(Utils.removeCredentialsFromURI(new URI(tempDir)).toString)
 
-    s"UNLOAD ('$query') TO '$fixedUrl' WITH CREDENTIALS '$credsString' ESCAPE MANIFEST"
+    val userUnloadOptions = params.parameters.getOrElse("extraunloadoptions", "")
+    val unloadOptions = (userUnloadOptions ++ Array("ESCAPE", "MANIFEST")
+      .filterNot(r => userUnloadOptions.contains(r))
+      .mkString(" ", " ", "")).trim
+
+    s"UNLOAD ('$query') TO '$fixedUrl' WITH CREDENTIALS '$credsString' $unloadOptions"
   }
 
   private def pruneSchema(schema: StructType, columns: Array[String]): StructType = {

--- a/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
@@ -555,4 +555,23 @@ class RedshiftSourceSuite
     }
     assert(e.getMessage.contains("Block FileSystem"))
   }
+
+  test("Can specifiy extraunloadoptions") {
+    val expectedQuery = (
+      "UNLOAD \\('SELECT \"testbyte\" FROM \"PUBLIC\".\"test_table\" '\\) " +
+        "TO '.*' " +
+        "WITH CREDENTIALS 'aws_access_key_id=test1;aws_secret_access_key=test2' " +
+        "DELIMITER ',' ESCAPE MANIFEST").r
+    val extraParams = defaultParams + ("extraunloadoptions" -> "DELIMITER ','")
+    val mockRedshift =
+      new MockRedshift(defaultParams("url"), Map("test_table" -> TestUtils.testSchema))
+    // Construct the source with a custom schema
+    val source = new DefaultSource(mockRedshift.jdbcWrapper, _ => mockS3Client)
+    val relation = source.createRelation(testSqlContext, extraParams, TestUtils.testSchema)
+
+    val rdd = relation.asInstanceOf[PrunedFilteredScan]
+      .buildScan(Array("testbyte"), Array.empty[Filter])
+    mockRedshift.verifyThatConnectionsWereClosed()
+    mockRedshift.verifyThatExpectedQueriesWereIssued(Seq(expectedQuery))
+  }
 }


### PR DESCRIPTION
Allow user to specify unload options like a custom delimiter for example
By default, "manifest" and "escape" options are always set

Example:
`.option("extraunloadoptions", "DELIMITER ','")`
