### PR TITLE
Add IAM role support for COPY/UNLOAD operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,8 +196,7 @@ This library reads and writes data to S3 when transferring data to/from Redshift
 
 There are four ways of configuring AWS credentials for use by this library:
 
-1. **Set the `aws_iam_role` parameter:** If set, this takes precedence over any other authentication option.  You will need to have this IAM role attached to the Redshift cluster which allows read/write access to your `tempdir` bucket.  More info [here](http://docs.aws.amazon.com/redshift/latest/mgmt/copy-unload-iam-role.html)
-2. **Set keys in Hadoop conf (best option for most users):** You can specify AWS keys via [Hadoop configuration properties](https://github.com/apache/hadoop/blob/trunk/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md). For example, if your `tempdir` configuration points to a `s3n://` filesystem then you can set the `fs.s3n.awsAccessKeyId` and `fs.s3n.awsSecretAccessKey` properties in a Hadoop XML configuration file or call `sc.hadoopConfiguration.set()` to mutate Spark's global Hadoop configuration.
+1. **Set keys in Hadoop conf (best option for most users):** You can specify AWS keys via [Hadoop configuration properties](https://github.com/apache/hadoop/blob/trunk/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md). For example, if your `tempdir` configuration points to a `s3n://` filesystem then you can set the `fs.s3n.awsAccessKeyId` and `fs.s3n.awsSecretAccessKey` properties in a Hadoop XML configuration file or call `sc.hadoopConfiguration.set()` to mutate Spark's global Hadoop configuration.
 
  For example, if you are using the `s3n` filesystem then add
 
@@ -220,7 +219,8 @@ There are four ways of configuring AWS credentials for use by this library:
  sc._jsc.hadoopConfiguration().set("fs.s3n.awsSecretAccessKey", "YOUR_SECRET_ACCESS_KEY")
  ```
 
-3. **Encode keys in `tempdir` URI**: For example, the URI `s3n://ACCESSKEY:SECRETKEY@bucket/path/to/temp/dir` encodes the key pair (`ACCESSKEY`, `SECRETKEY`). Due to [Hadoop limitations](https://issues.apache.org/jira/browse/HADOOP-3733), this approach will not work for secret keys which contain forward slash (`/`) characters.
+2. **Encode keys in `tempdir` URI**: For example, the URI `s3n://ACCESSKEY:SECRETKEY@bucket/path/to/temp/dir` encodes the key pair (`ACCESSKEY`, `SECRETKEY`). Due to [Hadoop limitations](https://issues.apache.org/jira/browse/HADOOP-3733), this approach will not work for secret keys which contain forward slash (`/`) characters.
+3. **Set the `aws_iam_role` parameter:** If set, this takes precedence over any other authentication option.  You will need to have this IAM role attached to the Redshift cluster which allows read/write access to your `tempdir` bucket.  More info [here](http://docs.aws.amazon.com/redshift/latest/mgmt/copy-unload-iam-role.html)
 4. **IAM instance profiles:** If you are running on EC2 and authenticate to S3 using IAM and [instance profiles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html), then you must must configure the `temporary_aws_access_key_id`, `temporary_aws_secret_access_key`, and `temporary_aws_session_token` configuration properties to point to temporary keys created via the AWS [Security Token Service](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html). These temporary keys will then be passed to Redshift via `LOAD` and `UNLOAD` commands.
 
 > **:warning: Note**: This library does not clean up the temporary files that it creates in S3. As a result, we recommend that you use a dedicated temporary S3 bucket with an [object lifecycle configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) to ensure that temporary files are automatically deleted after a specified expiration period.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,16 @@ df.write
     .option("tempdir", "s3n://path/for/temp/data")
   .mode("error")
   .save()
+  
+// Using IAM Role based authentication
+df.write
+  .format("com.databricks.spark.redshift")
+    .option("url", "jdbc:redshift://redshifthost:5439/database?user=username&password=pass")
+    .option("dbtable", "my_table_copy")
+    .option("aws_iam_role", "arn:aws:iam::123456789000:role/redshift_iam_role")
+    .option("tempdir", "s3n://path/for/temp/data")
+  .mode("error")
+  .save()
 ```
 
 #### Python
@@ -118,6 +128,17 @@ df.write \
   .option("url", "jdbc:redshift://redshifthost:5439/database?user=username&password=pass") \
   .option("dbtable", "my_table_copy") \
   .option("tempdir", "s3n://path/for/temp/data") \
+  .mode("error") \
+  .save()
+  
+  
+# Using IAM Role based authentication
+df.write \
+  .format("com.databricks.spark.redshift") \
+  .option("url", "jdbc:redshift://redshifthost:5439/database?user=username&password=pass") \
+  .option("dbtable", "my_table_copy") \
+  .option("tempdir", "s3n://path/for/temp/data") \
+  .option("aws_iam_role", "arn:aws:iam::123456789000:role/redshift_iam_role")
   .mode("error") \
   .save()
 ```
@@ -173,9 +194,10 @@ val records = sc.newAPIHadoopFile(
 
 This library reads and writes data to S3 when transferring data to/from Redshift. As a result, it requires AWS credentials with read and write access to a S3 bucket (specified using the `tempdir` configuration parameter). Assuming that Spark has been configured to access S3, it should automatically discover the proper credentials to pass to Redshift.
 
-There are three ways of configuring AWS credentials for use by this library:
+There are four ways of configuring AWS credentials for use by this library:
 
-1. **Set keys in Hadoop conf (best option for most users):** You can specify AWS keys via [Hadoop configuration properties](https://github.com/apache/hadoop/blob/trunk/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md). For example, if your `tempdir` configuration points to a `s3n://` filesystem then you can set the `fs.s3n.awsAccessKeyId` and `fs.s3n.awsSecretAccessKey` properties in a Hadoop XML configuration file or call `sc.hadoopConfiguration.set()` to mutate Spark's global Hadoop configuration.
+1. **Set the `aws_iam_role` parameter:** If set, this takes precedence over any other authentication option.  You will need to have this IAM role attached to the Redshift cluster which allows read/write access to your `tempdir` bucket.  More info [here](http://docs.aws.amazon.com/redshift/latest/mgmt/copy-unload-iam-role.html)
+2. **Set keys in Hadoop conf (best option for most users):** You can specify AWS keys via [Hadoop configuration properties](https://github.com/apache/hadoop/blob/trunk/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/index.md). For example, if your `tempdir` configuration points to a `s3n://` filesystem then you can set the `fs.s3n.awsAccessKeyId` and `fs.s3n.awsSecretAccessKey` properties in a Hadoop XML configuration file or call `sc.hadoopConfiguration.set()` to mutate Spark's global Hadoop configuration.
 
  For example, if you are using the `s3n` filesystem then add
 
@@ -198,8 +220,8 @@ There are three ways of configuring AWS credentials for use by this library:
  sc._jsc.hadoopConfiguration().set("fs.s3n.awsSecretAccessKey", "YOUR_SECRET_ACCESS_KEY")
  ```
 
-2. **Encode keys in `tempdir` URI**: For example, the URI `s3n://ACCESSKEY:SECRETKEY@bucket/path/to/temp/dir` encodes the key pair (`ACCESSKEY`, `SECRETKEY`). Due to [Hadoop limitations](https://issues.apache.org/jira/browse/HADOOP-3733), this approach will not work for secret keys which contain forward slash (`/`) characters.
-3. **IAM instance profiles:** If you are running on EC2 and authenticate to S3 using IAM and [instance profiles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html), then you must must configure the `temporary_aws_access_key_id`, `temporary_aws_secret_access_key`, and `temporary_aws_session_token` configuration properties to point to temporary keys created via the AWS [Security Token Service](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html). These temporary keys will then be passed to Redshift via `LOAD` and `UNLOAD` commands.
+3. **Encode keys in `tempdir` URI**: For example, the URI `s3n://ACCESSKEY:SECRETKEY@bucket/path/to/temp/dir` encodes the key pair (`ACCESSKEY`, `SECRETKEY`). Due to [Hadoop limitations](https://issues.apache.org/jira/browse/HADOOP-3733), this approach will not work for secret keys which contain forward slash (`/`) characters.
+4. **IAM instance profiles:** If you are running on EC2 and authenticate to S3 using IAM and [instance profiles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html), then you must must configure the `temporary_aws_access_key_id`, `temporary_aws_secret_access_key`, and `temporary_aws_session_token` configuration properties to point to temporary keys created via the AWS [Security Token Service](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html). These temporary keys will then be passed to Redshift via `LOAD` and `UNLOAD` commands.
 
 > **:warning: Note**: This library does not clean up the temporary files that it creates in S3. As a result, we recommend that you use a dedicated temporary S3 bucket with an [object lifecycle configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) to ensure that temporary files are automatically deleted after a specified expiration period.
 
@@ -256,6 +278,12 @@ need to be configured to allow access from your driver application.
  <li><tt>user</tt> and <tt>password</tt> are credentials to access the database, which must be embedded
     in this URL for JDBC, and your user account should have necessary privileges for the table being referenced. </li>
     </td>
+ </tr>
+ <tr>
+   <td><tt>aws_iam_role</tt></td>
+   <td>Only if using IAM roles to authorize Redshift COPY/UNLOAD operations</td>
+   <td>No default</td>
+   <td>Fully specified ARN of the <a href="http://docs.aws.amazon.com/redshift/latest/mgmt/copy-unload-iam-role.html">IAM Role</a> attached to the Redshift cluster, ex: arn:aws:iam::123456789000:role/redshift_iam_role</td>
  </tr>
  <tr>
     <td><tt>temporary_aws_access_key_id</tt></td>

--- a/src/main/scala/com/databricks/spark/redshift/Parameters.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Parameters.scala
@@ -229,6 +229,12 @@ private[redshift] object Parameters {
     def postActions: Array[String] = parameters("postactions").split(";")
 
     /**
+      * The IAM role to assume for Redshift COPY/UNLOAD operations.  This takes precedence over
+      * other forms of authentication.
+      */
+    def iamRole: Option[String] = parameters.get("aws_iam_role")
+
+    /**
      * Temporary AWS credentials which are passed to Redshift. These only need to be supplied by
      * the user when Hadoop is configured to authenticate to S3 via IAM roles assigned to EC2
      * instances.

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
@@ -171,7 +171,7 @@ private[redshift] case class RedshiftRelation(
     val columnList = requiredColumns.map(col => s""""$col"""").mkString(", ")
     val whereClause = FilterPushdown.buildWhereClause(schema, filters)
     val creds = AWSCredentialsUtils.load(params, sqlContext.sparkContext.hadoopConfiguration)
-    val credsString: String = AWSCredentialsUtils.getRedshiftCredentialsString(creds)
+    val credsString: String = AWSCredentialsUtils.getRedshiftCredentialsString(params, creds)
     val query = {
       // Since the query passed to UNLOAD will be enclosed in single quotes, we need to escape
       // any single quotes that appear in the query itself

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
@@ -95,7 +95,7 @@ private[redshift] class RedshiftWriter(
       params: MergedParameters,
       creds: AWSCredentials,
       manifestUrl: String): String = {
-    val credsString: String = AWSCredentialsUtils.getRedshiftCredentialsString(creds)
+    val credsString: String = AWSCredentialsUtils.getRedshiftCredentialsString(params, creds)
     val fixedUrl = Utils.fixS3Url(manifestUrl)
     s"COPY ${params.table.get} FROM '$fixedUrl' CREDENTIALS '$credsString' FORMAT AS " +
       s"AVRO 'auto' manifest ${params.extraCopyOptions}"

--- a/src/test/scala/com/databricks/spark/redshift/AWSCredentialsUtilsSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/AWSCredentialsUtilsSuite.scala
@@ -33,14 +33,24 @@ class AWSCredentialsUtilsSuite extends FunSuite {
 
   test("credentialsString with regular keys") {
     val creds = new BasicAWSCredentials("ACCESSKEYID", "SECRET/KEY/WITH/SLASHES")
-    assert(AWSCredentialsUtils.getRedshiftCredentialsString(creds) ===
+    val params = MergedParameters(Map.empty)
+    assert(AWSCredentialsUtils.getRedshiftCredentialsString(params, creds) ===
       "aws_access_key_id=ACCESSKEYID;aws_secret_access_key=SECRET/KEY/WITH/SLASHES")
   }
 
   test("credentialsString with STS temporary keys") {
     val creds = new BasicSessionCredentials("ACCESSKEYID", "SECRET/KEY", "SESSION/Token")
-    assert(AWSCredentialsUtils.getRedshiftCredentialsString(creds) ===
+    val params = MergedParameters(Map.empty)
+    assert(AWSCredentialsUtils.getRedshiftCredentialsString(params, creds) ===
       "aws_access_key_id=ACCESSKEYID;aws_secret_access_key=SECRET/KEY;token=SESSION/Token")
+  }
+
+  test("Configured IAM roles should take precedence") {
+    val creds = new BasicSessionCredentials("ACCESSKEYID", "SECRET/KEY", "SESSION/Token")
+    val iamRole = "arn:aws:iam::123456789000:role/redshift_iam_role"
+    val params = MergedParameters(Map("aws_iam_role" -> iamRole))
+    assert(AWSCredentialsUtils.getRedshiftCredentialsString(params, creds) ===
+      s"aws_iam_role=$iamRole")
   }
 
   test("AWSCredentials.load() STS temporary keys should take precedence") {


### PR DESCRIPTION
This fixes #199 

I have tested it out with one of our Redshift clusters and it seems to behave as expected.  Also I realized too late that there was a similar patch up (https://github.com/databricks/spark-redshift/pull/216/files).  Please feel free to close if you prefer that one.