### PR TITLE
Fix precision loss when unloading timestamps from Redshift

### DIFF
--- a/src/it/scala/com/databricks/spark/redshift/RedshiftIntegrationSuite.scala
+++ b/src/it/scala/com/databricks/spark/redshift/RedshiftIntegrationSuite.scala
@@ -640,4 +640,17 @@ class RedshiftIntegrationSuite extends IntegrationSuiteBase {
     // filter pushdown.
     checkAnswer(df.filter("testtimestamp = '2015-07-01 00:00:00.001'"), Seq(Row(timestamp)))
   }
+
+  test("full timestamp precision is preserved in loads (regression test for #214)") {
+    val timestamps = Seq(
+      TestUtils.toTimestamp(1970, 0, 1, 0, 0, 0, millis = 1),
+      TestUtils.toTimestamp(1970, 0, 1, 0, 0, 0, millis = 10),
+      TestUtils.toTimestamp(1970, 0, 1, 0, 0, 0, millis = 100),
+      TestUtils.toTimestamp(1970, 0, 1, 0, 0, 0, millis = 1000))
+    testRoundtripSaveAndLoad(
+      s"full_timestamp_precision_is_preserved$randomSuffix",
+      sqlContext.createDataFrame(sc.parallelize(timestamps.map(Row(_))),
+        StructType(StructField("ts", TimestampType) :: Nil))
+    )
+  }
 }

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
@@ -254,7 +254,7 @@ private[redshift] class RedshiftWriter(
     // spark-avro does not support Date types. In addition, it converts Timestamps into longs
     // (milliseconds since the Unix epoch). Redshift is capable of loading timestamps in
     // 'epochmillisecs' format but there's no equivalent format for dates. To work around this, we
-    // choose to write out both dates and timestamps as strings using the same timestamp format.
+    // choose to write out both dates and timestamps as strings.
     // For additional background and discussion, see #39.
 
     // Convert the rows so that timestamps and dates become formatted strings.
@@ -263,12 +263,12 @@ private[redshift] class RedshiftWriter(
     val conversionFunctions: Array[Any => Any] = data.schema.fields.map { field =>
       field.dataType match {
         case DateType =>
-          val dateFormat = new RedshiftDateFormat()
+          val dateFormat = Conversions.createRedshiftDateFormat()
           (v: Any) => {
             if (v == null) null else dateFormat.format(v.asInstanceOf[Date])
           }
         case TimestampType =>
-          val timestampFormat = new RedshiftTimestampFormat()
+          val timestampFormat = Conversions.createRedshiftTimestampFormat()
           (v: Any) => {
             if (v == null) null else timestampFormat.format(v.asInstanceOf[Timestamp])
           }

--- a/src/test/scala/com/databricks/spark/redshift/ConversionsSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/ConversionsSuite.scala
@@ -21,7 +21,7 @@ import java.sql.Timestamp
 import org.scalatest.FunSuite
 
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.types.{StructField, BooleanType, StructType}
+import org.apache.spark.sql.types.{TimestampType, StructField, BooleanType, StructType}
 
 /**
  * Unit test for data type conversions
@@ -65,6 +65,26 @@ class ConversionsSuite extends FunSuite {
     assert(convertRow(Array(null)) === Row(null))
     intercept[IllegalArgumentException] {
       convertRow(Array("not-a-boolean"))
+    }
+  }
+
+  test("timestamp conversion handles millisecond-level precision (regression test for #214)") {
+    val convertRow =
+      Conversions.createRowConverter(StructType(Seq(StructField("a", TimestampType))))
+    Seq(
+      "2014-03-01 00:00:01" -> TestUtils.toMillis(2014, 2, 1, 0, 0, 0, millis = 1000),
+      "2014-03-01 00:00:01.000" -> TestUtils.toMillis(2014, 2, 1, 0, 0, 0, millis = 1000),
+      "2014-03-01 00:00:00.1" -> TestUtils.toMillis(2014, 2, 1, 0, 0, 0, millis = 100),
+      "2014-03-01 00:00:00.10" -> TestUtils.toMillis(2014, 2, 1, 0, 0, 0, millis = 100),
+      "2014-03-01 00:00:00.100" -> TestUtils.toMillis(2014, 2, 1, 0, 0, 0, millis = 100),
+      "2014-03-01 00:00:00.01" -> TestUtils.toMillis(2014, 2, 1, 0, 0, 0, millis = 10),
+      "2014-03-01 00:00:00.010" -> TestUtils.toMillis(2014, 2, 1, 0, 0, 0, millis = 10),
+      "2014-03-01 00:00:00.001" -> TestUtils.toMillis(2014, 2, 1, 0, 0, 0, millis = 1)
+    ).foreach { case (timestampString, expectedTime) =>
+      withClue(s"timestamp string is '$timestampString'") {
+        val convertedTimestamp = convertRow(Array(timestampString)).get(0).asInstanceOf[Timestamp]
+        assert(convertedTimestamp === new Timestamp(expectedTime))
+      }
     }
   }
 }

--- a/src/test/scala/com/databricks/spark/redshift/TestUtils.scala
+++ b/src/test/scala/com/databricks/spark/redshift/TestUtils.scala
@@ -68,8 +68,8 @@ object TestUtils {
    */
   val expectedDataWithConvertedTimesAndDates: Seq[Row] = expectedData.map { row =>
     Row.fromSeq(row.toSeq.map {
-      case t: Timestamp => new RedshiftTimestampFormat().format(t)
-      case d: Date => new RedshiftDateFormat().format(d)
+      case t: Timestamp => Conversions.createRedshiftTimestampFormat().format(t)
+      case d: Date => Conversions.createRedshiftDateFormat().format(d)
       case other => other
     })
   }


### PR DESCRIPTION
This patch fixes a bug which led to loss of sub-second precision when unloading certain timestamps from Redshift.

In a nutshell, the problem is that Redshift's unloaded timestamps carry only the significant figures in sub-second components of the timestamp, so a timestamp such as `2016-05-27 00:27:41.100` is output as `2016-05-27 00:27:41.1` in the unload output, while one like `2016-05-27 00:27:41.123` is roundtripped with three significant sub-second digits.

From its earliest versions, `spark-redshift` incorrectly assumed that Redshift's unloaded timestamps would conform to either a `yyyy-MM-dd HH:mm:ss.SSS` or `yyyy-MM-dd HH:mm:ss` format, with either three full digits of sub-second precision or none ([source](https://github.com/databricks/spark-redshift/blob/141cf19901a4ad92e824c4fd337e2321d9b597f7/src/main/scala/com/databricks/spark/redshift/Conversions.scala#L51)), so the length of the timestamp string was used to select the DateFormat used for parsing. As a result, timestamps like `2016-05-27 00:27:41.1` would be routed to the "seconds-only" format, losing the sub-second information and leading to the bug reported in #204.

Note, however, that we can't simply fix this by using a different strategy to select the DateFormat (or a greater number of DateFormats); see https://stackoverflow.com/questions/7159895 for a full explanation of why this is the case.

Instead, this patch addresses this issue by using [`java.sql.Timestamp.valueOf`](https://docs.oracle.com/javase/6/docs/api/java/sql/Timestamp.html#valueOf(java.lang.String)), which properly handles fractional seconds,  to parse timestamps. I also removed a redundant date formatter implementation which was used for `Date` columns and have fixed a number of outdated code comments.

To test my fix, I added both end-to-end regression tests as well as unit tests in `ConversionsSuite`.

Fixes #214.

/cc @jaley @mwho