### PR TITLE
Fix decimal locale-sensitivity bug which caused incorrect reads

### DIFF
--- a/src/main/scala/com/databricks/spark/redshift/Conversions.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Conversions.scala
@@ -17,7 +17,8 @@
 package com.databricks.spark.redshift
 
 import java.sql.Timestamp
-import java.text.{DecimalFormat, SimpleDateFormat}
+import java.text.{DecimalFormat, DecimalFormatSymbols, SimpleDateFormat}
+import java.util.Locale
 
 import scala.collection.mutable
 
@@ -47,6 +48,7 @@ private[redshift] object Conversions {
   def createRedshiftDecimalFormat(): DecimalFormat = {
     val format = new DecimalFormat()
     format.setParseBigDecimal(true)
+    format.setDecimalFormatSymbols(new DecimalFormatSymbols(Locale.US))
     format
   }
 

--- a/src/test/scala/com/databricks/spark/redshift/ConversionsSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/ConversionsSuite.scala
@@ -17,6 +17,7 @@
 package com.databricks.spark.redshift
 
 import java.sql.Timestamp
+import java.util.Locale
 
 import org.scalatest.FunSuite
 
@@ -84,6 +85,18 @@ class ConversionsSuite extends FunSuite {
       withClue(s"timestamp string is '$timestampString'") {
         val convertedTimestamp = convertRow(Array(timestampString)).get(0).asInstanceOf[Timestamp]
         assert(convertedTimestamp === new Timestamp(expectedTime))
+      }
+    }
+  }
+
+  test("RedshiftDecimalFormat is locale-insensitive (regression test for #243)") {
+    for (locale <- Seq(Locale.US, Locale.GERMAN, Locale.UK)) {
+      withClue(s"locale = $locale") {
+        TestUtils.withDefaultLocale(locale) {
+          val decimalFormat = Conversions.createRedshiftDecimalFormat()
+          val parsed = decimalFormat.parse("151.20").asInstanceOf[java.math.BigDecimal]
+          assert(parsed.doubleValue() === 151.20)
+        }
       }
     }
   }

--- a/src/test/scala/com/databricks/spark/redshift/TestUtils.scala
+++ b/src/test/scala/com/databricks/spark/redshift/TestUtils.scala
@@ -17,7 +17,7 @@
 package com.databricks.spark.redshift
 
 import java.sql.{Date, Timestamp}
-import java.util.Calendar
+import java.util.{Calendar, Locale}
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
@@ -110,5 +110,15 @@ object TestUtils {
    */
   def toDate(year: Int, zeroBasedMonth: Int, date: Int): Date = {
     new Date(toTimestamp(year, zeroBasedMonth, date, 0, 0, 0).getTime)
+  }
+
+  def withDefaultLocale[T](newDefaultLocale: Locale)(block: => T): T = {
+    val originalDefaultLocale = Locale.getDefault
+    try {
+      Locale.setDefault(newDefaultLocale)
+      block
+    } finally {
+      Locale.setDefault(originalDefaultLocale)
+    }
   }
 }


### PR DESCRIPTION
This patch fixes an issue where our decimal parsing was locale-sensitive, causing the old code to return wrong answers when run in [locales that use commas as decimal marks](https://en.wikipedia.org/wiki/Decimal_mark#Countries_using_Arabic_numerals_with_decimal_comma). Redshift will always use a dot (".") as the decimal point, so we can fix this bug by explicitly specifying a US locale when creating our `DecimalFormat`.

Fixes #243.