### PR TITLE
Split COPY stmts and fix invalid s3 hostname exceptions with old aws-…

### DIFF
--- a/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
@@ -23,7 +23,7 @@ import java.net.URI
 import scala.collection.JavaConverters._
 
 import com.amazonaws.auth.AWSCredentials
-import com.amazonaws.services.s3.{AmazonS3Client, AmazonS3URI}
+import com.amazonaws.services.s3.AmazonS3Client
 import com.eclipsesource.json.Json
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.sources._
@@ -124,7 +124,7 @@ private[redshift] case class RedshiftRelation(
       val filesToRead: Seq[String] = {
         val cleanedTempDirUri =
           Utils.fixS3Url(Utils.removeCredentialsFromURI(URI.create(tempDir)).toString)
-        val s3URI = new AmazonS3URI(cleanedTempDirUri)
+        val s3URI = Utils.createS3URI(cleanedTempDirUri)
         val s3Client = s3ClientFactory(creds)
         val is = s3Client.getObject(s3URI.getBucket, s3URI.getKey + "manifest").getObjectContent
         val s3Files = try {

--- a/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
@@ -138,6 +138,7 @@ class RedshiftSourceSuite
       }
     }
     when(mockS3Client.getObject(anyString(), endsWith("manifest"))).thenReturn(mockManifest)
+    when(mockS3Client.getObject(anyString(), endsWith("manifest.json"))).thenReturn(mockManifest)
   }
 
   override def afterEach(): Unit = {

--- a/src/test/scala/com/databricks/spark/redshift/UtilsSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/UtilsSuite.scala
@@ -44,6 +44,11 @@ class UtilsSuite extends FunSuite with Matchers {
     Utils.fixS3Url("s3n://foo/bar/baz") shouldBe "s3://foo/bar/baz"
   }
 
+  test("addEndpointToUrl produces urls with endpoints added to host") {
+    Utils.addEndpointToUrl("s3a://foo/bar/12345") shouldBe "s3a://foo.s3.amazonaws.com/bar/12345"
+    Utils.addEndpointToUrl("s3n://foo/bar/baz") shouldBe "s3n://foo.s3.amazonaws.com/bar/baz"
+  }
+
   test("temp paths are random subdirectories of root") {
     val root = "s3n://temp/"
     val firstTempPath = Utils.makeTempPath(root)


### PR DESCRIPTION
…java-sdk

We've seen a lot of messages lately regarding the "Invalid S3 URI: hostname does not appear to be a valid S3 endpoint" exception and so thought we should contribute our two cents and the code changes that worked for us.  We've tried many approaches listed in that thread including using spark.executor.extraClassPath and spark.driver.extraClassPath environment variables to prepend to the classpath, including it in the assembled jar or as a shaded jar,  Unfortunately many of these approaches failed mainly because we have on the machines themselves the aws-java-sdk jar and that usually takes precedence.  We ended up going with what Josh mentioned earlier about changing the s3 url in the spark-redshift code to add the endpoint to the host (*.s3.amazonaws.com).

Furthermore, we also ran into an issue where writing a large amount of data would fail (> 300GB of compressed data).  We found that we could upload the data to s3 but when we execute the COPY statement for a single manifest, the operation would timeout.  As such, we break out the manifest and run the COPY statement on each of the entry urls in the manifest.