### PR TITLE
Handle invalid S3 hostname exceptions with older aws-java-sdk versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,15 @@ matrix:
     # Scala 2.10.5 tests:
     - jdk: openjdk7
       scala: 2.10.5
-      env: HADOOP_VERSION="2.2.0" SPARK_VERSION="2.0.0" SPARK_AVRO_VERSION="3.0.0"
+      env: HADOOP_VERSION="2.2.0" SPARK_VERSION="2.0.0" SPARK_AVRO_VERSION="3.0.0" AWS_JAVA_SDK_VERSION="1.10.22"
     # Scala 2.11 tests:
     - jdk: openjdk7
       scala: 2.11.7
-      env: HADOOP_VERSION="2.2.0" SPARK_VERSION="2.0.0" SPARK_AVRO_VERSION="3.0.0"
+      env: HADOOP_VERSION="2.2.0" SPARK_VERSION="2.0.0" SPARK_AVRO_VERSION="3.0.0" AWS_JAVA_SDK_VERSION="1.10.22"
+    # Test with an old version of the AWS Java SDK
+    - jdk: openjdk7
+      scala: 2.11.7
+      env: HADOOP_VERSION="2.2.0" SPARK_VERSION="2.0.0" SPARK_AVRO_VERSION="3.0.0" AWS_JAVA_SDK_VERSION="1.7.4"
 env:
   global:
     # AWS_REDSHIFT_JDBC_URL

--- a/dev/run-tests-travis.sh
+++ b/dev/run-tests-travis.sh
@@ -7,6 +7,7 @@ sbt ++$TRAVIS_SCALA_VERSION "test:scalastyle"
 sbt ++$TRAVIS_SCALA_VERSION "it:scalastyle"
 
 sbt \
+  -Daws.testVersion=$AWS_JAVA_SDK_VERSION \
   -Dhadoop.testVersion=$HADOOP_VERSION \
   -Dspark.testVersion=$SPARK_VERSION \
   -DsparkAvro.testVersion=$SPARK_AVRO_VERSION \
@@ -15,6 +16,7 @@ sbt \
 
 if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then
   sbt \
+    -Daws.testVersion=$AWS_JAVA_SDK_VERSION \
     -Dhadoop.testVersion=$HADOOP_VERSION \
     -Dspark.testVersion=$SPARK_VERSION \
     -DsparkAvro.testVersion=$SPARK_AVRO_VERSION \

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,3 +18,5 @@ addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+
+libraryDependencies += "org.apache.maven" % "maven-artifact" % "3.3.9"

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
@@ -23,7 +23,7 @@ import java.net.URI
 import scala.collection.JavaConverters._
 
 import com.amazonaws.auth.AWSCredentials
-import com.amazonaws.services.s3.{AmazonS3Client, AmazonS3URI}
+import com.amazonaws.services.s3.AmazonS3Client
 import com.eclipsesource.json.Json
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.sources._
@@ -124,7 +124,7 @@ private[redshift] case class RedshiftRelation(
       val filesToRead: Seq[String] = {
         val cleanedTempDirUri =
           Utils.fixS3Url(Utils.removeCredentialsFromURI(URI.create(tempDir)).toString)
-        val s3URI = new AmazonS3URI(cleanedTempDirUri)
+        val s3URI = Utils.createS3URI(cleanedTempDirUri)
         val s3Client = s3ClientFactory(creds)
         val is = s3Client.getObject(s3URI.getBucket, s3URI.getKey + "manifest").getObjectContent
         val s3Files = try {

--- a/src/main/scala/com/databricks/spark/redshift/Utils.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Utils.scala
@@ -80,7 +80,7 @@ private[redshift] object Utils {
    */
   def addEndpointToUrl(url: String, domain: String = "s3.amazonaws.com"): String = {
     val uri = new URI(url)
-    val hostWithEndpoint = uri.getHost() + "." + domain
+    val hostWithEndpoint = uri.getHost + "." + domain
     new URI(uri.getScheme,
       uri.getUserInfo,
       hostWithEndpoint,

--- a/src/main/scala/com/databricks/spark/redshift/Utils.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Utils.scala
@@ -60,7 +60,8 @@ private[redshift] object Utils {
   }
 
   /**
-   * Factory method to create new S3URI in order to handle various library incompatabilities with older AWS Java Libraries
+   * Factory method to create new S3URI in order to handle various library incompatabilities with
+   * older AWS Java Libraries
    */
   def createS3URI(url: String): AmazonS3URI = {
     try {
@@ -68,7 +69,8 @@ private[redshift] object Utils {
       new AmazonS3URI(url)
     } catch {
       case e: java.lang.IllegalArgumentException => {
-        if (e.getMessage().startsWith("Invalid S3 URI: hostname does not appear to be a valid S3 endpoint")) {
+        if (e.getMessage().
+          startsWith("Invalid S3 URI: hostname does not appear to be a valid S3 endpoint")) {
           new AmazonS3URI(addEndpointToUrl(url))
         } else {
           throw e

--- a/src/main/scala/com/databricks/spark/redshift/Utils.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Utils.scala
@@ -60,6 +60,40 @@ private[redshift] object Utils {
   }
 
   /**
+   * Factory method to create new S3URI in order to handle various library incompatabilities with older AWS Java Libraries
+   */
+  def createS3URI(url: String): AmazonS3URI = {
+    try {
+      // try to instantiate AmazonS3URI with url
+      new AmazonS3URI(url)
+    } catch {
+      case e: java.lang.IllegalArgumentException => {
+        if (e.getMessage().startsWith("Invalid S3 URI: hostname does not appear to be a valid S3 endpoint")) {
+          new AmazonS3URI(addEndpointToUrl(url))
+        } else {
+          throw e
+        }
+      }
+    }
+  }
+
+  /**
+   * Since older AWS Java Libraries do not handle S3 urls that have just the bucket name
+   * as the host, add the endpoint to the host
+   */
+  def addEndpointToUrl(url: String, domain: String = "s3.amazonaws.com"): String = {
+    val uri = new URI(url)
+    val hostWithEndpoint = uri.getHost() + "." + domain
+    new URI(uri.getScheme(),
+      uri.getUserInfo(),
+      hostWithEndpoint,
+      uri.getPort(),
+      uri.getPath(),
+      uri.getQuery(),
+      uri.getFragment()).toString
+  }
+
+  /**
    * Returns a copy of the given URI with the user credentials removed.
    */
   def removeCredentialsFromURI(uri: URI): URI = {
@@ -87,7 +121,7 @@ private[redshift] object Utils {
       tempDir: String,
       s3Client: AmazonS3Client): Unit = {
     try {
-      val s3URI = new AmazonS3URI(Utils.fixS3Url(tempDir))
+      val s3URI = createS3URI(Utils.fixS3Url(tempDir))
       val bucket = s3URI.getBucket
       assert(bucket != null, "Could not get bucket from S3 URI")
       val key = Option(s3URI.getKey).getOrElse("")

--- a/src/main/scala/com/databricks/spark/redshift/Utils.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Utils.scala
@@ -68,7 +68,8 @@ private[redshift] object Utils {
       // try to instantiate AmazonS3URI with url
       new AmazonS3URI(url)
     } catch {
-      case e: IllegalArgumentException if e.getMessage.startsWith("Invalid S3 URI: hostname does not appear to be a valid S3 endpoint") => {
+      case e: IllegalArgumentException if e.getMessage.
+        startsWith("Invalid S3 URI: hostname does not appear to be a valid S3 endpoint") => {
         new AmazonS3URI(addEndpointToUrl(url))
       }
     }

--- a/src/main/scala/com/databricks/spark/redshift/Utils.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Utils.scala
@@ -60,7 +60,7 @@ private[redshift] object Utils {
   }
 
   /**
-   * Factory method to create new S3URI in order to handle various library incompatabilities with
+   * Factory method to create new S3URI in order to handle various library incompatibilities with
    * older AWS Java Libraries
    */
   def createS3URI(url: String): AmazonS3URI = {
@@ -68,13 +68,8 @@ private[redshift] object Utils {
       // try to instantiate AmazonS3URI with url
       new AmazonS3URI(url)
     } catch {
-      case e: java.lang.IllegalArgumentException => {
-        if (e.getMessage().
-          startsWith("Invalid S3 URI: hostname does not appear to be a valid S3 endpoint")) {
-          new AmazonS3URI(addEndpointToUrl(url))
-        } else {
-          throw e
-        }
+      case e: IllegalArgumentException if e.getMessage.startsWith("Invalid S3 URI: hostname does not appear to be a valid S3 endpoint") => {
+        new AmazonS3URI(addEndpointToUrl(url))
       }
     }
   }
@@ -86,13 +81,13 @@ private[redshift] object Utils {
   def addEndpointToUrl(url: String, domain: String = "s3.amazonaws.com"): String = {
     val uri = new URI(url)
     val hostWithEndpoint = uri.getHost() + "." + domain
-    new URI(uri.getScheme(),
-      uri.getUserInfo(),
+    new URI(uri.getScheme,
+      uri.getUserInfo,
       hostWithEndpoint,
-      uri.getPort(),
-      uri.getPath(),
-      uri.getQuery(),
-      uri.getFragment()).toString
+      uri.getPort,
+      uri.getPath,
+      uri.getQuery,
+      uri.getFragment).toString
   }
 
   /**

--- a/src/test/scala/com/databricks/spark/redshift/UtilsSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/UtilsSuite.scala
@@ -44,6 +44,11 @@ class UtilsSuite extends FunSuite with Matchers {
     Utils.fixS3Url("s3n://foo/bar/baz") shouldBe "s3://foo/bar/baz"
   }
 
+  test("addEndpointToUrl produces urls with endpoints added to host") {
+    Utils.addEndpointToUrl("s3a://foo/bar/12345") shouldBe "s3a://foo.s3.amazonaws.com/bar/12345"
+    Utils.addEndpointToUrl("s3n://foo/bar/baz") shouldBe "s3n://foo.s3.amazonaws.com/bar/baz"
+  }
+
   test("temp paths are random subdirectories of root") {
     val root = "s3n://temp/"
     val firstTempPath = Utils.makeTempPath(root)


### PR DESCRIPTION
We've seen a lot of messages lately regarding the "Invalid S3 URI: hostname does not appear to be a valid S3 endpoint" exception and so thought we should contribute our two cents and the code changes that worked for us. We've tried many approaches listed in that thread including using `spark.executor.extraClassPath` and `spark.driver.extraClassPath` environment variables to prepend to the classpath, including it in the assembled jar or as a shaded jar, Unfortunately many of these approaches failed mainly because we have on the machines themselves the older aws-java-sdk jar and that usually takes precedence. We ended up going with what Josh mentioned earlier about changing the S3 url in the spark-redshift code to add the endpoint to the host (`*.s3.amazonaws.com`).

This logic will try to instantiate a new AmazonS3URI and if it fails, it'll try to add the default S3 Amazon domain to the host.