### PR TITLE
Fix reading of NaN and Infinity

### DIFF
--- a/src/main/scala/com/databricks/spark/redshift/Conversions.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Conversions.scala
@@ -86,8 +86,18 @@ private[redshift] object Conversions {
         case ByteType => (data: String) => data.toByte
         case BooleanType => (data: String) => parseBoolean(data)
         case DateType => (data: String) => new java.sql.Date(dateFormat.parse(data).getTime)
-        case DoubleType => (data: String) => data.toDouble
-        case FloatType => (data: String) => data.toFloat
+        case DoubleType => (data: String) => data.toLowerCase match {
+          case "nan" => Double.NaN
+          case "infinity" => Double.PositiveInfinity
+          case "-infinity" => Double.NegativeInfinity
+          case _ => java.lang.Double.parseDouble(data)
+        }
+        case FloatType => (data: String) => data.toLowerCase match {
+          case "nan" => Float.NaN
+          case "infinity" => Float.PositiveInfinity
+          case "-infinity" => Float.NegativeInfinity
+          case _ => java.lang.Float.parseFloat(data)
+        }
         case dt: DecimalType =>
           (data: String) => decimalFormat.parse(data).asInstanceOf[java.math.BigDecimal]
         case IntegerType => (data: String) => data.toInt

--- a/src/main/scala/com/databricks/spark/redshift/Conversions.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Conversions.scala
@@ -83,7 +83,7 @@ private[redshift] object Conversions {
     val decimalFormat = createRedshiftDecimalFormat()
     val conversionFunctions: Array[String => Any] = schema.fields.map { field =>
       field.dataType match {
-        case ByteType => (data: String) => data.toByte
+        case ByteType => (data: String) => java.lang.Byte.parseByte(data)
         case BooleanType => (data: String) => parseBoolean(data)
         case DateType => (data: String) => new java.sql.Date(dateFormat.parse(data).getTime)
         case DoubleType => (data: String) => data.toLowerCase match {
@@ -100,9 +100,9 @@ private[redshift] object Conversions {
         }
         case dt: DecimalType =>
           (data: String) => decimalFormat.parse(data).asInstanceOf[java.math.BigDecimal]
-        case IntegerType => (data: String) => data.toInt
-        case LongType => (data: String) => data.toLong
-        case ShortType => (data: String) => data.toShort
+        case IntegerType => (data: String) => java.lang.Integer.parseInt(data)
+        case LongType => (data: String) => java.lang.Long.parseLong(data)
+        case ShortType => (data: String) => java.lang.Short.parseShort(data)
         case StringType => (data: String) => data
         case TimestampType => (data: String) => Timestamp.valueOf(data)
         case _ => (data: String) => data

--- a/src/main/scala/com/databricks/spark/redshift/Conversions.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Conversions.scala
@@ -86,16 +86,16 @@ private[redshift] object Conversions {
         case ByteType => (data: String) => java.lang.Byte.parseByte(data)
         case BooleanType => (data: String) => parseBoolean(data)
         case DateType => (data: String) => new java.sql.Date(dateFormat.parse(data).getTime)
-        case DoubleType => (data: String) => data.toLowerCase match {
+        case DoubleType => (data: String) => data match {
           case "nan" => Double.NaN
-          case "infinity" => Double.PositiveInfinity
-          case "-infinity" => Double.NegativeInfinity
+          case "inf" => Double.PositiveInfinity
+          case "-inf" => Double.NegativeInfinity
           case _ => java.lang.Double.parseDouble(data)
         }
-        case FloatType => (data: String) => data.toLowerCase match {
+        case FloatType => (data: String) => data match {
           case "nan" => Float.NaN
-          case "infinity" => Float.PositiveInfinity
-          case "-infinity" => Float.NegativeInfinity
+          case "inf" => Float.PositiveInfinity
+          case "-inf" => Float.NegativeInfinity
           case _ => java.lang.Float.parseFloat(data)
         }
         case dt: DecimalType =>

--- a/src/test/scala/com/databricks/spark/redshift/ConversionsSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/ConversionsSuite.scala
@@ -22,7 +22,7 @@ import java.util.Locale
 import org.scalatest.FunSuite
 
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.types.{TimestampType, StructField, BooleanType, StructType}
+import org.apache.spark.sql.types._
 
 /**
  * Unit test for data type conversions
@@ -99,5 +99,21 @@ class ConversionsSuite extends FunSuite {
         }
       }
     }
+  }
+
+  test("Row conversion properly handles NaN and Inf float values (regression test for #261)") {
+    val convertRow = Conversions.createRowConverter(StructType(Seq(StructField("a", FloatType))))
+    assert(java.lang.Float.isNaN(convertRow(Array("nan")).getFloat(0)))
+    assert(java.lang.Float.isNaN(convertRow(Array("NaN")).getFloat(0)))
+    assert(convertRow(Array("Infinity")) === Row(Float.PositiveInfinity))
+    assert(convertRow(Array("-Infinity")) === Row(Float.NegativeInfinity))
+  }
+
+  test("Row conversion properly handles NaN and Inf double values (regression test for #261)") {
+    val convertRow = Conversions.createRowConverter(StructType(Seq(StructField("a", DoubleType))))
+    assert(java.lang.Double.isNaN(convertRow(Array("nan")).getDouble(0)))
+    assert(java.lang.Double.isNaN(convertRow(Array("nan")).getDouble(0)))
+    assert(convertRow(Array("Infinity")) === Row(Double.PositiveInfinity))
+    assert(convertRow(Array("-Infinity")) === Row(Double.NegativeInfinity))
   }
 }

--- a/src/test/scala/com/databricks/spark/redshift/ConversionsSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/ConversionsSuite.scala
@@ -104,16 +104,14 @@ class ConversionsSuite extends FunSuite {
   test("Row conversion properly handles NaN and Inf float values (regression test for #261)") {
     val convertRow = Conversions.createRowConverter(StructType(Seq(StructField("a", FloatType))))
     assert(java.lang.Float.isNaN(convertRow(Array("nan")).getFloat(0)))
-    assert(java.lang.Float.isNaN(convertRow(Array("NaN")).getFloat(0)))
-    assert(convertRow(Array("Infinity")) === Row(Float.PositiveInfinity))
-    assert(convertRow(Array("-Infinity")) === Row(Float.NegativeInfinity))
+    assert(convertRow(Array("inf")) === Row(Float.PositiveInfinity))
+    assert(convertRow(Array("-inf")) === Row(Float.NegativeInfinity))
   }
 
   test("Row conversion properly handles NaN and Inf double values (regression test for #261)") {
     val convertRow = Conversions.createRowConverter(StructType(Seq(StructField("a", DoubleType))))
     assert(java.lang.Double.isNaN(convertRow(Array("nan")).getDouble(0)))
-    assert(java.lang.Double.isNaN(convertRow(Array("nan")).getDouble(0)))
-    assert(convertRow(Array("Infinity")) === Row(Double.PositiveInfinity))
-    assert(convertRow(Array("-Infinity")) === Row(Double.NegativeInfinity))
+    assert(convertRow(Array("inf")) === Row(Double.PositiveInfinity))
+    assert(convertRow(Array("-inf")) === Row(Double.NegativeInfinity))
   }
 }


### PR DESCRIPTION
This patch fixes a bug which caused `spark-redshift` to throw `NumberFormatException` when reading NaN or Infinity from Redshift.

This patch fixes the bug by adding special-case handling of the string constants `nan`, `inf`, and `-inf`, which are the values sent back by Redshift during unloads. Note that we still do not support loads of `NaN` to Redshift since Redshift itself does not seem to support this yet (https://forums.aws.amazon.com/thread.jspa?threadID=236367).

Fixes #261.