### PR TITLE
Pass around AWSCredentialProviders instead of AWSCredentials

### DIFF
--- a/src/main/scala/com/databricks/spark/redshift/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/redshift/DefaultSource.scala
@@ -16,7 +16,7 @@
 
 package com.databricks.spark.redshift
 
-import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.s3.AmazonS3Client
 import org.apache.spark.sql.sources.{BaseRelation, CreatableRelationProvider, RelationProvider, SchemaRelationProvider}
 import org.apache.spark.sql.types.StructType
@@ -26,7 +26,9 @@ import org.slf4j.LoggerFactory
 /**
  * Redshift Source implementation for Spark SQL
  */
-class DefaultSource(jdbcWrapper: JDBCWrapper, s3ClientFactory: AWSCredentials => AmazonS3Client)
+class DefaultSource(
+    jdbcWrapper: JDBCWrapper,
+    s3ClientFactory: AWSCredentialsProvider => AmazonS3Client)
   extends RelationProvider
   with SchemaRelationProvider
   with CreatableRelationProvider {

--- a/src/main/scala/com/databricks/spark/redshift/Parameters.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Parameters.scala
@@ -234,7 +234,7 @@ private[redshift] object Parameters {
      * Temporary AWS credentials which are passed to Redshift. These only need to be supplied by
      * the user when Hadoop is configured to authenticate to S3 via IAM roles assigned to EC2
      * instances.
-     */credentials
+     */
     def temporaryAWSCredentials: Option[AWSCredentialsProvider] = {
       for (
         accessKey <- parameters.get("temporary_aws_access_key_id");

--- a/src/main/scala/com/databricks/spark/redshift/Parameters.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Parameters.scala
@@ -16,7 +16,7 @@
 
 package com.databricks.spark.redshift
 
-import com.amazonaws.auth.{AWSCredentials, BasicSessionCredentials}
+import com.amazonaws.auth.{AWSCredentialsProvider, BasicSessionCredentials}
 
 /**
  * All user-specifiable parameters for spark-redshift, along with their validation rules and
@@ -234,13 +234,16 @@ private[redshift] object Parameters {
      * Temporary AWS credentials which are passed to Redshift. These only need to be supplied by
      * the user when Hadoop is configured to authenticate to S3 via IAM roles assigned to EC2
      * instances.
-     */
-    def temporaryAWSCredentials: Option[AWSCredentials] = {
+     */credentials
+    def temporaryAWSCredentials: Option[AWSCredentialsProvider] = {
       for (
         accessKey <- parameters.get("temporary_aws_access_key_id");
         secretAccessKey <- parameters.get("temporary_aws_secret_access_key");
         sessionToken <- parameters.get("temporary_aws_session_token")
-      ) yield new BasicSessionCredentials(accessKey, secretAccessKey, sessionToken)
+      ) yield {
+        AWSCredentialsUtils.staticCredentialsProvider(
+          new BasicSessionCredentials(accessKey, secretAccessKey, sessionToken))
+      }
     }
   }
 }

--- a/src/test/scala/com/databricks/spark/redshift/AWSCredentialsUtilsSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/AWSCredentialsUtilsSuite.scala
@@ -65,7 +65,7 @@ class AWSCredentialsUtilsSuite extends FunSuite {
       "temporary_aws_session_token" -> "token"
     ))
 
-    val creds = AWSCredentialsUtils.load(params, conf)
+    val creds = AWSCredentialsUtils.load(params, conf).getCredentials
     assert(creds.isInstanceOf[AWSSessionCredentials])
     assert(creds.getAWSAccessKeyId === "key_id")
     assert(creds.getAWSSecretKey === "secret")
@@ -78,13 +78,13 @@ class AWSCredentialsUtilsSuite extends FunSuite {
     conf.set("fs.s3.awsSecretAccessKey", "CONFKEY")
 
     {
-      val creds = AWSCredentialsUtils.load("s3://URIID:URIKEY@bucket/path", conf)
+      val creds = AWSCredentialsUtils.load("s3://URIID:URIKEY@bucket/path", conf).getCredentials
       assert(creds.getAWSAccessKeyId === "URIID")
       assert(creds.getAWSSecretKey === "URIKEY")
     }
 
     {
-      val creds = AWSCredentialsUtils.load("s3://bucket/path", conf)
+      val creds = AWSCredentialsUtils.load("s3://bucket/path", conf).getCredentials
       assert(creds.getAWSAccessKeyId === "CONFID")
       assert(creds.getAWSSecretKey === "CONFKEY")
     }
@@ -97,13 +97,13 @@ class AWSCredentialsUtilsSuite extends FunSuite {
     conf.set("fs.s3n.awsSecretAccessKey", "CONFKEY")
 
     {
-      val creds = AWSCredentialsUtils.load("s3n://URIID:URIKEY@bucket/path", conf)
+      val creds = AWSCredentialsUtils.load("s3n://URIID:URIKEY@bucket/path", conf).getCredentials
       assert(creds.getAWSAccessKeyId === "URIID")
       assert(creds.getAWSSecretKey === "URIKEY")
     }
 
     {
-      val creds = AWSCredentialsUtils.load("s3n://bucket/path", conf)
+      val creds = AWSCredentialsUtils.load("s3n://bucket/path", conf).getCredentials
       assert(creds.getAWSAccessKeyId === "CONFID")
       assert(creds.getAWSSecretKey === "CONFKEY")
     }
@@ -116,13 +116,13 @@ class AWSCredentialsUtilsSuite extends FunSuite {
     conf.set("fs.s3a.secret.key", "CONFKEY")
 
     {
-      val creds = AWSCredentialsUtils.load("s3a://URIID:URIKEY@bucket/path", conf)
+      val creds = AWSCredentialsUtils.load("s3a://URIID:URIKEY@bucket/path", conf).getCredentials
       assert(creds.getAWSAccessKeyId === "URIID")
       assert(creds.getAWSSecretKey === "URIKEY")
     }
 
     {
-      val creds = AWSCredentialsUtils.load("s3a://bucket/path", conf)
+      val creds = AWSCredentialsUtils.load("s3a://bucket/path", conf).getCredentials
       assert(creds.getAWSAccessKeyId === "CONFID")
       assert(creds.getAWSSecretKey === "CONFKEY")
     }


### PR DESCRIPTION
This patch refactors the library internals to pass around `AWSCredentialProvider` instances instead of `AWSCredentials`, helping to avoid issues where temporary credentials are obtained at the start of a read or write operation and then expire when they are re-used later in the operation.

This fixes #200.