### PR TITLE
Add documentation and warnings related to using different regions for Redshift and S3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,8 @@ env:
     - secure: "cuyemI1bqPkWBD5B1FqIKDJb5g/SX5x8lrzkO0J/jkyGY0VLbHxrl5j/9PrKFuvraBK3HC56HEP1Zg+IMvh+uv0D+p5y14C97fAzE33uNgR2aVkamOo92zHvxvXe7zBtqc8rztWsJb1pgkrY7SdgSXgQc88ohey+XecDh4TahTY="
     # AWS_S3_SCRATCH_SPACE
     - secure: "LvndQIW6dHs6nyaMHtblGI/oL+s460lOezFs2BoD0Isenb/O/IM+nY5K9HepTXjJIcq8qvUYnojZX1FCrxxOXX2/+/Iihiq7GzJYdmdMC6hLg9bJYeAFk0dWYT88/AwadrJCBOa3ockRLhiO3dkai7Ki5+M1erfaFiAHHMpJxYQ="
+    # AWS_S3_CROSS_REGION_SCRATCH_SPACE
+    - secure: "esYmBqt256Dc77HT68zoaE/vtsFGk2N+Kt+52RlR0cjHPY1q5801vxLbeOlpYb2On3x8YckE++HadjL40gwSBsca0ffoogq6zTlfbJYDSQkQG1evxXWJZLcafB0igfBs/UbEUo7EaxoAJQcLgiWWwUdO0a0iU1ciSVyogZPagL0="
 
 script:
   - ./dev/run-tests-travis.sh

--- a/src/it/scala/com/databricks/spark/redshift/CrossRegionIntegrationSuite.scala
+++ b/src/it/scala/com/databricks/spark/redshift/CrossRegionIntegrationSuite.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2016 Databricks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.databricks.spark.redshift
+
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.services.s3.AmazonS3Client
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
+
+/**
+ * Integration tests where the Redshift cluster and the S3 bucket are in different AWS regions.
+ */
+class CrossRegionIntegrationSuite extends IntegrationSuiteBase {
+
+  protected val AWS_S3_CROSS_REGION_SCRATCH_SPACE: String =
+    loadConfigFromEnv("AWS_S3_CROSS_REGION_SCRATCH_SPACE")
+  require(AWS_S3_CROSS_REGION_SCRATCH_SPACE.contains("s3n"), "must use s3n:// URL")
+
+  override protected val tempDir: String = AWS_S3_CROSS_REGION_SCRATCH_SPACE + randomSuffix + "/"
+
+  test("write") {
+    val bucketRegion = Utils.getRegionForS3Bucket(
+      tempDir,
+      new AmazonS3Client(new BasicAWSCredentials(AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY))).get
+    val df = sqlContext.createDataFrame(sc.parallelize(Seq(Row(1)), 1),
+      StructType(StructField("foo", IntegerType) :: Nil))
+    val tableName = s"roundtrip_save_and_load_$randomSuffix"
+    try {
+      df.write
+        .format("com.databricks.spark.redshift")
+        .option("url", jdbcUrl)
+        .option("dbtable", tableName)
+        .option("tempdir", tempDir)
+        .option("extracopyoptions", s"region '$bucketRegion'")
+        .save()
+      // Check that the table exists. It appears that creating a table in one connection then
+      // immediately querying for existence from another connection may result in spurious "table
+      // doesn't exist" errors; this caused the "save with all empty partitions" test to become
+      // flaky (see #146). To work around this, add a small sleep and check again:
+      if (!DefaultJDBCWrapper.tableExists(conn, tableName)) {
+        Thread.sleep(1000)
+        assert(DefaultJDBCWrapper.tableExists(conn, tableName))
+      }
+    } finally {
+      conn.prepareStatement(s"drop table if exists $tableName").executeUpdate()
+      conn.commit()
+    }
+  }
+}

--- a/src/main/scala/com/databricks/spark/redshift/Utils.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Utils.scala
@@ -192,7 +192,7 @@ private[redshift] object Utils {
    * proxy.
    */
   def getRegionForRedshiftCluster(url: String): Option[String] = {
-    val regionRegex = """.*\.([^.]+)\.redshift.amazonaws.com.*""".r
+    val regionRegex = """.*\.([^.]+)\.redshift\.amazonaws\.com.*""".r
     url match {
       case regionRegex(region) => Some(region)
       case _ => None

--- a/src/test/scala/com/databricks/spark/redshift/UtilsSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/UtilsSuite.scala
@@ -66,4 +66,11 @@ class UtilsSuite extends FunSuite with Matchers {
       removeCreds("s3n://ACCESSKEY:SECRETKEY@bucket/path/to/temp/dir") ===
       "s3n://bucket/path/to/temp/dir")
   }
+
+  test("getRegionForRedshiftCluster") {
+    val redshiftUrl =
+      "jdbc:redshift://example.secret.us-west-2.redshift.amazonaws.com:5439/database"
+    assert(Utils.getRegionForRedshiftCluster("mycluster.example.com") === None)
+    assert(Utils.getRegionForRedshiftCluster(redshiftUrl) === Some("us-west-2"))
+  }
 }


### PR DESCRIPTION
Redshift throws extremely confusing errors when the Redshift cluster and S3 bucket are in different AWS regions. This patch expands the documentation to discuss how to fix these errors and adds logic to attempt to automatically detect and warn users when this case occurs.

Fixes #87.