### PR TITLE
Use CSV data source to read unloaded data from Redshift

### DIFF
--- a/src/main/scala/com/databricks/spark/redshift/Conversions.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Conversions.scala
@@ -78,7 +78,7 @@ private[redshift] object Conversions {
    *
    * Note that instances of this function are NOT thread-safe.
    */
-  def createRowConverter(schema: StructType): (Array[String]) => Row = {
+  def createRowConverter(schema: StructType): Row => Row = {
     val dateFormat = createRedshiftDateFormat()
     val decimalFormat = createRedshiftDecimalFormat()
     val conversionFunctions: Array[String => Any] = schema.fields.map { field =>
@@ -110,10 +110,10 @@ private[redshift] object Conversions {
     }
     // As a performance optimization, re-use the same mutable Seq:
     val converted: mutable.IndexedSeq[Any] = mutable.IndexedSeq.fill(schema.length)(null)
-    (fields: Array[String]) => {
+    (inputRow: Row) => {
       var i = 0
       while (i < schema.length) {
-        val data = fields(i)
+        val data = inputRow.getString(i)
         converted(i) = if (data == null || data.isEmpty) null else conversionFunctions(i)(data)
         i += 1
       }

--- a/src/main/scala/com/databricks/spark/redshift/Utils.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Utils.scala
@@ -105,10 +105,16 @@ private[redshift] object Utils {
       uri.getFragment)
   }
 
+  // Visible for testing
+  private[redshift] var lastTempPathGenerated: String = null
+
   /**
    * Creates a randomly named temp directory path for intermediate data
    */
-  def makeTempPath(tempRoot: String): String = Utils.joinUrls(tempRoot, UUID.randomUUID().toString)
+  def makeTempPath(tempRoot: String): String = {
+    lastTempPathGenerated = Utils.joinUrls(tempRoot, UUID.randomUUID().toString)
+    lastTempPathGenerated
+  }
 
   /**
    * Checks whether the S3 bucket for the given UI has an object lifecycle configuration to

--- a/src/test/scala/com/databricks/spark/redshift/ConversionsSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/ConversionsSuite.scala
@@ -43,7 +43,7 @@ class ConversionsSuite extends FunSuite {
     val expectedTimestampMillis = TestUtils.toMillis(2014, 2, 1, 0, 0, 1, 123)
 
     val convertedRow = convertRow(
-      Array("1", "t", "2015-07-01", doubleMin, "1.0", "42",
+      Row("1", "t", "2015-07-01", doubleMin, "1.0", "42",
         longMax, "23", unicodeString, timestampWithMillis))
 
     val expectedRow = Row(1.asInstanceOf[Byte], true, new Timestamp(expectedDateMillis),
@@ -55,17 +55,17 @@ class ConversionsSuite extends FunSuite {
 
   test("Row conversion handles null values") {
     val convertRow = Conversions.createRowConverter(TestUtils.testSchema)
-    val emptyRow = List.fill(TestUtils.testSchema.length)(null).toArray[String]
-    assert(convertRow(emptyRow) === Row(emptyRow: _*))
+    val emptyRow = Row.fromSeq(List.fill(TestUtils.testSchema.length)(null))
+    assert(convertRow(emptyRow) === emptyRow)
   }
 
   test("Booleans are correctly converted") {
     val convertRow = Conversions.createRowConverter(StructType(Seq(StructField("a", BooleanType))))
-    assert(convertRow(Array("t")) === Row(true))
-    assert(convertRow(Array("f")) === Row(false))
-    assert(convertRow(Array(null)) === Row(null))
+    assert(convertRow(Row("t")) === Row(true))
+    assert(convertRow(Row("f")) === Row(false))
+    assert(convertRow(Row(null)) === Row(null))
     intercept[IllegalArgumentException] {
-      convertRow(Array("not-a-boolean"))
+      convertRow(Row("not-a-boolean"))
     }
   }
 
@@ -83,7 +83,7 @@ class ConversionsSuite extends FunSuite {
       "2014-03-01 00:00:00.001" -> TestUtils.toMillis(2014, 2, 1, 0, 0, 0, millis = 1)
     ).foreach { case (timestampString, expectedTime) =>
       withClue(s"timestamp string is '$timestampString'") {
-        val convertedTimestamp = convertRow(Array(timestampString)).get(0).asInstanceOf[Timestamp]
+        val convertedTimestamp = convertRow(Row(timestampString)).get(0).asInstanceOf[Timestamp]
         assert(convertedTimestamp === new Timestamp(expectedTime))
       }
     }
@@ -103,15 +103,15 @@ class ConversionsSuite extends FunSuite {
 
   test("Row conversion properly handles NaN and Inf float values (regression test for #261)") {
     val convertRow = Conversions.createRowConverter(StructType(Seq(StructField("a", FloatType))))
-    assert(java.lang.Float.isNaN(convertRow(Array("nan")).getFloat(0)))
-    assert(convertRow(Array("inf")) === Row(Float.PositiveInfinity))
-    assert(convertRow(Array("-inf")) === Row(Float.NegativeInfinity))
+    assert(java.lang.Float.isNaN(convertRow(Row("nan")).getFloat(0)))
+    assert(convertRow(Row("inf")) === Row(Float.PositiveInfinity))
+    assert(convertRow(Row("-inf")) === Row(Float.NegativeInfinity))
   }
 
   test("Row conversion properly handles NaN and Inf double values (regression test for #261)") {
     val convertRow = Conversions.createRowConverter(StructType(Seq(StructField("a", DoubleType))))
-    assert(java.lang.Double.isNaN(convertRow(Array("nan")).getDouble(0)))
-    assert(convertRow(Array("inf")) === Row(Double.PositiveInfinity))
-    assert(convertRow(Array("-inf")) === Row(Double.NegativeInfinity))
+    assert(java.lang.Double.isNaN(convertRow(Row("nan")).getDouble(0)))
+    assert(convertRow(Row("inf")) === Row(Double.PositiveInfinity))
+    assert(convertRow(Row("-inf")) === Row(Double.NegativeInfinity))
   }
 }


### PR DESCRIPTION
This patch refactors this library's read path to use Spark 2.0's built-in CSV data source to read unloaded Redshift output from S3. This approach has a few advantages over our existing custom-InputFormat-based code:

- It will benefit from performance improvements in `FileScanRDD` and `HadoopFsRelation`, including automatic coalescing.
- The Univocity CSV parser is likely to be faster than our old custom code.
- We don't have to create a separate RDD per partition and union them together, making the RDD DAG smaller.

In order to do this, I had to change the `UNLOAD` command to add the `ADDQUOTES` option. Previously, the unloaded data used `|` as a delimiter and used `\|` to escape that delimiter, but it appears that Spark's CSV data source isn't able to handle non-quoted escaping of delimiters (@falaki, could you confirm?). I believe that this should be safe, but it would be great to figure out why this library didn't take this approach in the first place. @jaley, do you know of any gotchas in doing this?