### PR TITLE
Use FileFormat-based data source instead of HadoopRDD for reads

### DIFF
--- a/project/SparkRedshiftBuild.scala
+++ b/project/SparkRedshiftBuild.scala
@@ -70,6 +70,8 @@ object SparkRedshiftBuild extends Build {
         } else {
           "org.apache.avro" % "avro-mapred" % "1.7.7" % "provided" classifier "hadoop2" exclude("org.mortbay.jetty", "servlet-api")
         },
+        // Kryo is provided by Spark, but we need this here in order to be able to import KryoSerializable
+        "com.esotericsoftware" % "kryo-shaded" % "3.0.3" % "provided",
         // A Redshift-compatible JDBC driver must be present on the classpath for spark-redshift to work.
         // For testing, we use an Amazon driver, which is available from
         // http://docs.aws.amazon.com/redshift/latest/mgmt/configure-jdbc-connection.html

--- a/src/it/scala/com/databricks/spark/redshift/RedshiftReadSuite.scala
+++ b/src/it/scala/com/databricks/spark/redshift/RedshiftReadSuite.scala
@@ -46,8 +46,7 @@ class RedshiftReadSuite extends IntegrationSuiteBase {
     read.option("dbtable", test_table).load().createOrReplaceTempView("test_table")
   }
 
-  test("DefaultSource can load Redshift UNLOAD output to a DataFrame 111") {
-    sqlContext.sparkContext.setLogLevel("DEBUG")
+  test("DefaultSource can load Redshift UNLOAD output to a DataFrame") {
     checkAnswer(
       sqlContext.sql("select * from test_table"),
       TestUtils.expectedData)
@@ -236,7 +235,6 @@ class RedshiftReadSuite extends IntegrationSuiteBase {
       checkAnswer(
         read.option("dbtable", tableName).load(),
         Seq("a\nb", "\\", "\"").map(x => Row.apply(x)))
-      Thread.sleep(1000 * 60)
     }
   }
 }

--- a/src/main/scala/com/databricks/spark/redshift/Conversions.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Conversions.scala
@@ -78,7 +78,7 @@ private[redshift] object Conversions {
    *
    * Note that instances of this function are NOT thread-safe.
    */
-  def createRowConverter(schema: StructType): (Array[String]) => Row = {
+  def createRowConverter(schema: StructType): Row => Row = {
     val dateFormat = createRedshiftDateFormat()
     val decimalFormat = createRedshiftDecimalFormat()
     val conversionFunctions: Array[String => Any] = schema.fields.map { field =>
@@ -110,10 +110,10 @@ private[redshift] object Conversions {
     }
     // As a performance optimization, re-use the same mutable Seq:
     val converted: mutable.IndexedSeq[Any] = mutable.IndexedSeq.fill(schema.length)(null)
-    (fields: Array[String]) => {
+    (inputRow: Row) => {
       var i = 0
       while (i < schema.length) {
-        val data = fields(i)
+        val data = inputRow.getString(i)
         converted(i) = if (data == null || data.isEmpty) null else conversionFunctions(i)(data)
         i += 1
       }

--- a/src/main/scala/com/databricks/spark/redshift/RecordReaderIterator.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RecordReaderIterator.scala
@@ -20,13 +20,9 @@ package com.databricks.spark.redshift
 import java.io.Closeable
 
 import org.apache.hadoop.mapreduce.RecordReader
-import org.apache.spark.sql.catalyst.InternalRow
 
 /**
  * An adaptor from a Hadoop [[RecordReader]] to an [[Iterator]] over the values returned.
- *
- * Note that this returns [[Object]]s instead of [[InternalRow]] because we rely on erasure to pass
- * column batches by pretending they are rows.
  *
  * This is copied from Apache Spark and is inlined here to avoid depending on Spark internals
  * in this external library.

--- a/src/main/scala/com/databricks/spark/redshift/RecordReaderIterator.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RecordReaderIterator.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.databricks.spark.redshift
+
+import java.io.Closeable
+
+import org.apache.hadoop.mapreduce.RecordReader
+import org.apache.spark.sql.catalyst.InternalRow
+
+/**
+ * An adaptor from a Hadoop [[RecordReader]] to an [[Iterator]] over the values returned.
+ *
+ * Note that this returns [[Object]]s instead of [[InternalRow]] because we rely on erasure to pass
+ * column batches by pretending they are rows.
+ *
+ * This is copied from Apache Spark and is inlined here to avoid depending on Spark internals
+ * in this external library.
+ */
+private[redshift] class RecordReaderIterator[T](
+  private[this] var rowReader: RecordReader[_, T]) extends Iterator[T] with Closeable {
+  private[this] var havePair = false
+  private[this] var finished = false
+
+  override def hasNext: Boolean = {
+    if (!finished && !havePair) {
+      finished = !rowReader.nextKeyValue
+      if (finished) {
+        // Close and release the reader here; close() will also be called when the task
+        // completes, but for tasks that read from many files, it helps to release the
+        // resources early.
+        close()
+      }
+      havePair = !finished
+    }
+    !finished
+  }
+
+  override def next(): T = {
+    if (!hasNext) {
+      throw new java.util.NoSuchElementException("End of stream")
+    }
+    havePair = false
+    rowReader.getCurrentValue
+  }
+
+  override def close(): Unit = {
+    if (rowReader != null) {
+      try {
+        // Close the reader and release it. Note: it's very important that we don't close the
+        // reader more than once, since that exposes us to MAPREDUCE-5918 when running against
+        // older Hadoop 2.x releases. That bug can lead to non-deterministic corruption issues
+        // when reading compressed input.
+        rowReader.close()
+      } finally {
+        rowReader = null
+      }
+    }
+  }
+}

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftFileFormat.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftFileFormat.scala
@@ -57,11 +57,8 @@ private[redshift] class RedshiftFileFormat extends FileFormat {
       sparkSession: SparkSession,
       options: Map[String, String],
       path: Path): Boolean = {
-    // Redshift unload files are not splittable because records containing newline characters may
-    // span multiple lines. This is true even if the ESCAPE unload option is used, since that option
-    // causes Redshift to simply prepend the '\' character rather than replacing newlines with
-    // escape sequences.
-    false
+    // Our custom InputFormat handles split records properly
+    true
   }
 
   override def buildReader(

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftFileFormat.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftFileFormat.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2016 Databricks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.databricks.spark.redshift
+
+import java.net.URI
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileStatus, Path}
+import org.apache.hadoop.mapreduce._
+import org.apache.hadoop.mapreduce.lib.input.FileSplit
+import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl
+import org.apache.spark.TaskContext
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.datasources._
+import org.apache.spark.sql.sources.Filter
+import org.apache.spark.sql.types.StructType
+
+/**
+ * Internal data source used for reading Redshift UNLOAD files.
+ *
+ * This is not intended for public consumption / use outside of this package and therefore
+ * no API stability is guaranteed.
+ */
+private[redshift] class RedshiftFileFormat extends FileFormat {
+  override def inferSchema(
+      sparkSession: SparkSession,
+      options: Map[String, String],
+      files: Seq[FileStatus]): Option[StructType] = {
+    // Schema is provided by caller.
+    None
+  }
+
+  override def prepareWrite(
+      sparkSession: SparkSession,
+      job: Job,
+      options: Map[String, String],
+      dataSchema: StructType): OutputWriterFactory = {
+    throw new UnsupportedOperationException(s"prepareWrite is not supported for $this")
+  }
+
+  override def isSplitable(
+      sparkSession: SparkSession,
+      options: Map[String, String],
+      path: Path): Boolean = {
+    // Redshift unload files are not splittable because records containing newline characters may
+    // span multiple lines. This is true even if the ESCAPE unload option is used, since that option
+    // causes Redshift to simply prepend the '\' character rather than replacing newlines with
+    // escape sequences.
+    false
+  }
+
+  override def buildReader(
+      sparkSession: SparkSession,
+      dataSchema: StructType,
+      partitionSchema: StructType,
+      requiredSchema: StructType,
+      filters: Seq[Filter],
+      options: Map[String, String],
+      hadoopConf: Configuration): (PartitionedFile) => Iterator[InternalRow] = {
+
+    require(partitionSchema.isEmpty)
+    require(filters.isEmpty)
+    require(dataSchema == requiredSchema)
+
+    val broadcastedConf =
+      sparkSession.sparkContext.broadcast(new SerializableConfiguration(hadoopConf))
+
+    (file: PartitionedFile) => {
+      val conf = broadcastedConf.value.value
+
+      val fileSplit = new FileSplit(
+        new Path(new URI(file.filePath)),
+        file.start,
+        file.length,
+        // TODO: Implement Locality
+        Array.empty)
+      val attemptId = new TaskAttemptID(new TaskID(new JobID(), TaskType.MAP, 0), 0)
+      val hadoopAttemptContext = new TaskAttemptContextImpl(conf, attemptId)
+      val reader = new RedshiftRecordReader
+      reader.initialize(fileSplit, hadoopAttemptContext)
+      val iter = new RecordReaderIterator[Array[String]](reader)
+      // Ensure that the record reader is closed upon task completion. It will ordinarily
+      // be closed once it is completely iterated, but this is necessary to guard against
+      // resource leaks in case the task fails or is interrupted.
+      Option(TaskContext.get()).foreach(_.addTaskCompletionListener(_ => iter.close()))
+      val converter = Conversions.createRowConverter(requiredSchema)
+      iter.map(converter)
+    }
+  }
+}

--- a/src/main/scala/com/databricks/spark/redshift/SerializableConfiguration.scala
+++ b/src/main/scala/com/databricks/spark/redshift/SerializableConfiguration.scala
@@ -27,7 +27,7 @@ import scala.util.control.NonFatal
 
 class SerializableConfiguration(@transient var value: Configuration)
     extends Serializable with KryoSerializable {
-  @transient private[avro] lazy val log = LoggerFactory.getLogger(getClass)
+  @transient private[redshift] lazy val log = LoggerFactory.getLogger(getClass)
 
   private def writeObject(out: ObjectOutputStream): Unit = tryOrIOException {
     out.defaultWriteObject()

--- a/src/main/scala/com/databricks/spark/redshift/SerializableConfiguration.scala
+++ b/src/main/scala/com/databricks/spark/redshift/SerializableConfiguration.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016 Databricks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.databricks.spark.redshift
+
+import java.io._
+
+import com.esotericsoftware.kryo.io.{Input, Output}
+import com.esotericsoftware.kryo.{Kryo, KryoSerializable}
+import org.apache.hadoop.conf.Configuration
+import org.slf4j.LoggerFactory
+
+import scala.util.control.NonFatal
+
+class SerializableConfiguration(@transient var value: Configuration)
+    extends Serializable with KryoSerializable {
+  @transient private[avro] lazy val log = LoggerFactory.getLogger(getClass)
+
+  private def writeObject(out: ObjectOutputStream): Unit = tryOrIOException {
+    out.defaultWriteObject()
+    value.write(out)
+  }
+
+  private def readObject(in: ObjectInputStream): Unit = tryOrIOException {
+    value = new Configuration(false)
+    value.readFields(in)
+  }
+
+  private def tryOrIOException[T](block: => T): T = {
+    try {
+      block
+    } catch {
+      case e: IOException =>
+        log.error("Exception encountered", e)
+        throw e
+      case NonFatal(e) =>
+        log.error("Exception encountered", e)
+        throw new IOException(e)
+    }
+  }
+
+  def write(kryo: Kryo, out: Output): Unit = {
+    val dos = new DataOutputStream(out)
+    value.write(dos)
+    dos.flush()
+  }
+
+  def read(kryo: Kryo, in: Input): Unit = {
+    value = new Configuration(false)
+    value.readFields(new DataInputStream(in))
+  }
+}

--- a/src/main/scala/com/databricks/spark/redshift/Utils.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Utils.scala
@@ -105,10 +105,16 @@ private[redshift] object Utils {
       uri.getFragment)
   }
 
+  // Visible for testing
+  private[redshift] var lastTempPathGenerated: String = null
+
   /**
    * Creates a randomly named temp directory path for intermediate data
    */
-  def makeTempPath(tempRoot: String): String = Utils.joinUrls(tempRoot, UUID.randomUUID().toString)
+  def makeTempPath(tempRoot: String): String = {
+    lastTempPathGenerated = Utils.joinUrls(tempRoot, UUID.randomUUID().toString)
+    lastTempPathGenerated
+  }
 
   /**
    * Checks whether the S3 bucket for the given UI has an object lifecycle configuration to

--- a/src/test/scala/com/databricks/spark/redshift/ConversionsSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/ConversionsSuite.scala
@@ -30,8 +30,12 @@ import org.apache.spark.sql.types._
  */
 class ConversionsSuite extends FunSuite {
 
+  private def createRowConverter(schema: StructType) = {
+    Conversions.createRowConverter(schema).andThen(RowEncoder(schema).resolveAndBind().fromRow)
+  }
+
   test("Data should be correctly converted") {
-    val convertRow = Conversions.createRowConverter(TestUtils.testSchema)
+    val convertRow = createRowConverter(TestUtils.testSchema)
     val doubleMin = Double.MinValue.toString
     val longMax = Long.MaxValue.toString
     // scalastyle:off
@@ -55,13 +59,13 @@ class ConversionsSuite extends FunSuite {
   }
 
   test("Row conversion handles null values") {
-    val convertRow = Conversions.createRowConverter(TestUtils.testSchema)
+    val convertRow = createRowConverter(TestUtils.testSchema)
     val emptyRow = List.fill(TestUtils.testSchema.length)(null).toArray[String]
     assert(convertRow(emptyRow) === Row(emptyRow: _*))
   }
 
   test("Booleans are correctly converted") {
-    val convertRow = Conversions.createRowConverter(StructType(Seq(StructField("a", BooleanType))))
+    val convertRow = createRowConverter(StructType(Seq(StructField("a", BooleanType))))
     assert(convertRow(Array("t")) === Row(true))
     assert(convertRow(Array("f")) === Row(false))
     assert(convertRow(Array(null)) === Row(null))
@@ -72,7 +76,7 @@ class ConversionsSuite extends FunSuite {
 
   test("timestamp conversion handles millisecond-level precision (regression test for #214)") {
     val schema = StructType(Seq(StructField("a", TimestampType)))
-    val convertRow = Conversions.createRowConverter(schema)
+    val convertRow = createRowConverter(schema)
     Seq(
       "2014-03-01 00:00:01" -> TestUtils.toMillis(2014, 2, 1, 0, 0, 0, millis = 1000),
       "2014-03-01 00:00:01.000" -> TestUtils.toMillis(2014, 2, 1, 0, 0, 0, millis = 1000),
@@ -84,9 +88,8 @@ class ConversionsSuite extends FunSuite {
       "2014-03-01 00:00:00.001" -> TestUtils.toMillis(2014, 2, 1, 0, 0, 0, millis = 1)
     ).foreach { case (timestampString, expectedTime) =>
       withClue(s"timestamp string is '$timestampString'") {
-        val convertedInternalRow = convertRow(Array(timestampString))
-        val convertedExternalRow = RowEncoder(schema).fromRow(convertedInternalRow)
-        val convertedTimestamp = convertedExternalRow.get(0).asInstanceOf[Timestamp]
+        val convertedRow = convertRow(Array(timestampString))
+        val convertedTimestamp = convertedRow.get(0).asInstanceOf[Timestamp]
         assert(convertedTimestamp === new Timestamp(expectedTime))
       }
     }
@@ -105,14 +108,14 @@ class ConversionsSuite extends FunSuite {
   }
 
   test("Row conversion properly handles NaN and Inf float values (regression test for #261)") {
-    val convertRow = Conversions.createRowConverter(StructType(Seq(StructField("a", FloatType))))
+    val convertRow = createRowConverter(StructType(Seq(StructField("a", FloatType))))
     assert(java.lang.Float.isNaN(convertRow(Array("nan")).getFloat(0)))
     assert(convertRow(Array("inf")) === Row(Float.PositiveInfinity))
     assert(convertRow(Array("-inf")) === Row(Float.NegativeInfinity))
   }
 
   test("Row conversion properly handles NaN and Inf double values (regression test for #261)") {
-    val convertRow = Conversions.createRowConverter(StructType(Seq(StructField("a", DoubleType))))
+    val convertRow = createRowConverter(StructType(Seq(StructField("a", DoubleType))))
     assert(java.lang.Double.isNaN(convertRow(Array("nan")).getDouble(0)))
     assert(convertRow(Array("inf")) === Row(Double.PositiveInfinity))
     assert(convertRow(Array("-inf")) === Row(Double.NegativeInfinity))

--- a/src/test/scala/com/databricks/spark/redshift/ConversionsSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/ConversionsSuite.scala
@@ -43,7 +43,7 @@ class ConversionsSuite extends FunSuite {
     val expectedTimestampMillis = TestUtils.toMillis(2014, 2, 1, 0, 0, 1, 123)
 
     val convertedRow = convertRow(
-      Array("1", "t", "2015-07-01", doubleMin, "1.0", "42",
+      Row("1", "t", "2015-07-01", doubleMin, "1.0", "42",
         longMax, "23", unicodeString, timestampWithMillis))
 
     val expectedRow = Row(1.asInstanceOf[Byte], true, new Timestamp(expectedDateMillis),
@@ -55,17 +55,17 @@ class ConversionsSuite extends FunSuite {
 
   test("Row conversion handles null values") {
     val convertRow = Conversions.createRowConverter(TestUtils.testSchema)
-    val emptyRow = List.fill(TestUtils.testSchema.length)(null).toArray[String]
-    assert(convertRow(emptyRow) === Row(emptyRow: _*))
+    val emptyRow = Row.fromSeq(List.fill(TestUtils.testSchema.length)(null))
+    assert(convertRow(emptyRow) === emptyRow)
   }
 
   test("Booleans are correctly converted") {
     val convertRow = Conversions.createRowConverter(StructType(Seq(StructField("a", BooleanType))))
-    assert(convertRow(Array("t")) === Row(true))
-    assert(convertRow(Array("f")) === Row(false))
-    assert(convertRow(Array(null)) === Row(null))
+    assert(convertRow(Row("t")) === Row(true))
+    assert(convertRow(Row("f")) === Row(false))
+    assert(convertRow(Row(null)) === Row(null))
     intercept[IllegalArgumentException] {
-      convertRow(Array("not-a-boolean"))
+      convertRow(Row("not-a-boolean"))
     }
   }
 
@@ -83,7 +83,7 @@ class ConversionsSuite extends FunSuite {
       "2014-03-01 00:00:00.001" -> TestUtils.toMillis(2014, 2, 1, 0, 0, 0, millis = 1)
     ).foreach { case (timestampString, expectedTime) =>
       withClue(s"timestamp string is '$timestampString'") {
-        val convertedTimestamp = convertRow(Array(timestampString)).get(0).asInstanceOf[Timestamp]
+        val convertedTimestamp = convertRow(Row(timestampString)).get(0).asInstanceOf[Timestamp]
         assert(convertedTimestamp === new Timestamp(expectedTime))
       }
     }
@@ -103,15 +103,15 @@ class ConversionsSuite extends FunSuite {
 
   test("Row conversion properly handles NaN and Inf float values (regression test for #261)") {
     val convertRow = Conversions.createRowConverter(StructType(Seq(StructField("a", FloatType))))
-    assert(java.lang.Float.isNaN(convertRow(Array("nan")).getFloat(0)))
-    assert(convertRow(Array("inf")) === Row(Float.PositiveInfinity))
-    assert(convertRow(Array("-inf")) === Row(Float.NegativeInfinity))
+    assert(java.lang.Float.isNaN(convertRow(Row("nan")).getFloat(0)))
+    assert(convertRow(Row("inf")) === Row(Float.PositiveInfinity))
+    assert(convertRow(Row("-inf")) === Row(Float.NegativeInfinity))
   }
 
   test("Row conversion properly handles NaN and Inf double values (regression test for #261)") {
     val convertRow = Conversions.createRowConverter(StructType(Seq(StructField("a", DoubleType))))
-    assert(java.lang.Double.isNaN(convertRow(Array("nan")).getDouble(0)))
-    assert(convertRow(Array("inf")) === Row(Double.PositiveInfinity))
-    assert(convertRow(Array("-inf")) === Row(Double.NegativeInfinity))
+    assert(java.lang.Double.isNaN(convertRow(Row("nan")).getDouble(0)))
+    assert(convertRow(Row("inf")) === Row(Double.PositiveInfinity))
+    assert(convertRow(Row("-inf")) === Row(Double.NegativeInfinity))
   }
 }

--- a/src/test/scala/com/databricks/spark/redshift/SerializableConfigurationSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/SerializableConfigurationSuite.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 Databricks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.databricks.spark.redshift
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.spark.SparkConf
+import org.apache.spark.serializer.{JavaSerializer, KryoSerializer, SerializerInstance}
+import org.scalatest.FunSuite
+
+class SerializableConfigurationSuite extends FunSuite {
+
+  private def testSerialization(serializer: SerializerInstance): Unit = {
+    val conf = new SerializableConfiguration(new Configuration())
+
+    val serialized = serializer.serialize(conf)
+
+    serializer.deserialize[Any](serialized) match {
+      case c: SerializableConfiguration =>
+        assert(c.log != null, "log was null")
+        assert(c.value != null, "value was null")
+      case other => fail(
+        s"Expecting ${classOf[SerializableConfiguration]}, but got ${other.getClass}.")
+    }
+  }
+
+  test("serialization with JavaSerializer") {
+    testSerialization(new JavaSerializer(new SparkConf()).newInstance())
+  }
+
+  test("serialization with KryoSerializer") {
+    testSerialization(new KryoSerializer(new SparkConf()).newInstance())
+  }
+
+}


### PR DESCRIPTION
This patch refactors this library's read path to use a Spark 2.0's `FileFormat`-based data source to read unloaded Redshift output from S3. This approach has a few advantages over using our existing `HadoopRDD`-based approach:

- It will benefit from performance improvements in `FileScanRDD` and `HadoopFsRelation`, including automatic coalescing.
- We don't have to create a separate RDD per partition and union them together, making the RDD DAG smaller.

The bulk of the diff are helper classes copied from Spark and `spark-avro` and inlined here for API compatibility / stability purposes. Some of the new classes implemented here are likely to become incompatible with new releases of Spark, but note that `spark-avro` itself relies on similar unstable / experimental APIs and thus this library is already vulnerable to changes to those APIs (in other words, this change is not making our compatibility story significantly worse).