### PR TITLE
Wrap and re-throw Await.result exceptions in order to capture full stacktrace

### DIFF
--- a/src/it/scala/com/databricks/spark/redshift/IAMIntegrationSuite.scala
+++ b/src/it/scala/com/databricks/spark/redshift/IAMIntegrationSuite.scala
@@ -68,7 +68,7 @@ class IAMIntegrationSuite extends IntegrationSuiteBase {
           .mode(SaveMode.ErrorIfExists)
           .save()
       }
-      assert(err.getMessage.contains("is not authorized to assume IAM Role"))
+      assert(err.getCause.getMessage.contains("is not authorized to assume IAM Role"))
     } finally {
       conn.prepareStatement(s"drop table if exists $tableName").executeUpdate()
       conn.commit()

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftJDBCWrapper.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftJDBCWrapper.scala
@@ -128,6 +128,9 @@ private[redshift] class JDBCWrapper {
       try {
         Await.result(future, Duration.Inf)
       } catch {
+        case e: SQLException =>
+          // Wrap and re-throw so that this thread's stacktrace appears to the user.
+          throw new SQLException("Exception thrown in awaitResult: ", e)
         case NonFatal(t) =>
           // Wrap and re-throw so that this thread's stacktrace appears to the user.
           throw new Exception("Exception thrown in awaitResult: ", t)


### PR DESCRIPTION
Exceptions thrown from Scala's `Await.result` don't include the waiting thread's stacktrace, making it hard to figure out where errors occur. Similar to the fix implemented in Spark in https://github.com/apache/spark/pull/12433, this patch modifies our `Await.result` usages to wrap and rethrow exceptions to capture the calling thread's stack.