### PR TITLE
Use PreparedStatement.getMetaData() to retrieve Redshift query schemas

### DIFF
--- a/src/it/scala/com/databricks/spark/redshift/RedshiftReadSuite.scala
+++ b/src/it/scala/com/databricks/spark/redshift/RedshiftReadSuite.scala
@@ -17,6 +17,7 @@
 package com.databricks.spark.redshift
 
 import org.apache.spark.sql.{execution, Row}
+import org.apache.spark.sql.types.LongType
 
 /**
  * End-to-end tests of functionality which only impacts the read path (e.g. filter pushdown).
@@ -236,5 +237,12 @@ class RedshiftReadSuite extends IntegrationSuiteBase {
         read.option("dbtable", tableName).load(),
         Seq("a\nb", "\\", "\"").map(x => Row.apply(x)))
     }
+  }
+
+  test("read result of approximate count(distinct) query (#300)") {
+    val df = read
+      .option("query", s"select approximate count(distinct testbool) as c from $test_table")
+      .load()
+    assert(df.schema.fields(0).dataType === LongType)
   }
 }

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftJDBCWrapper.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftJDBCWrapper.scala
@@ -151,6 +151,10 @@ private[redshift] class JDBCWrapper {
    * @throws SQLException if the table contains an unsupported type.
    */
   def resolveTable(conn: Connection, table: String): StructType = {
+    // It's important to leave the WHERE 1=0 clause in order to limit the work of the query in case
+    // the underlying JDBC driver implementation implements PreparedStatement.getMetaData() by
+    // executing the query. It looks like the standard Redshift and Postgres JDBC drivers don't do
+    // this but we leave the WHERE condition here as a safety-net to guard against perf regressions.
     val ps = conn.prepareStatement(s"SELECT * FROM $table WHERE 1=0")
     try {
       val rsmd = executeInterruptibly(ps, _.getMetaData)


### PR DESCRIPTION
Previously, this library issued a query against Redshift and inspected the ResultSet's metadata to determine the column names and types. Unfortunately, this approach does not work in a few corner-cases, including retrieving the schema of queries which use the `approximate count(distinct ...)` construct.

This patch fixes this issue by modifying our code to call `getMetaData()` on the prepared statement rather than running the query.   

Fixes #300.