### PR TITLE
Test infra housekeeping: reduce SBT memory, update plugin versions, update SBT

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,0 +1,7 @@
+-Dfile.encoding=UTF8
+-Xms1024M
+-Xmx1024M
+-Xss6M
+-XX:MaxPermSize=512m
+-XX:+CMSClassUnloadingEnabled
+-XX:+UseConcMarkSweepGC

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
 language: scala
 sudo: false
+# Cache settings here are based on latest SBT documentation.
 cache:
   directories:
-    - $HOME/.ivy2
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt/boot/
+before_cache:
+  # Tricks to avoid unnecessary cache updates
+  - find $HOME/.ivy2 -name "ivydata-*.properties" -delete
+  - find $HOME/.sbt -name "*.lock" -delete
 # There's no nicer way to specify this matrix; see
 # https://github.com/travis-ci/travis-ci/issues/1519.
 matrix:

--- a/dev/run-tests-travis.sh
+++ b/dev/run-tests-travis.sh
@@ -12,7 +12,7 @@ sbt \
   -Dspark.testVersion=$SPARK_VERSION \
   -DsparkAvro.testVersion=$SPARK_AVRO_VERSION \
   ++$TRAVIS_SCALA_VERSION \
-  coverage test
+  coverage test coverageReport
 
 if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then
   sbt \
@@ -21,5 +21,5 @@ if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then
     -Dspark.testVersion=$SPARK_VERSION \
     -DsparkAvro.testVersion=$SPARK_AVRO_VERSION \
     ++$TRAVIS_SCALA_VERSION \
-    coverage it:test 2> /dev/null;
+    coverage it:test coverageReport 2> /dev/null;
 fi

--- a/project/SparkRedshiftBuild.scala
+++ b/project/SparkRedshiftBuild.scala
@@ -20,7 +20,7 @@ import org.scalastyle.sbt.ScalastylePlugin.rawScalastyleSettings
 import sbt._
 import sbt.Keys._
 import sbtsparkpackage.SparkPackagePlugin.autoImport._
-import scoverage.ScoverageSbtPlugin
+import scoverage.ScoverageKeys
 import sbtrelease.ReleasePlugin.autoImport._
 import sbtrelease.ReleasePlugin.autoImport.ReleaseTransformations._
 import com.typesafe.sbt.pgp._
@@ -141,7 +141,7 @@ object SparkRedshiftBuild extends Build {
           x => x.data.getName.contains("hadoop1") && x.data.getName.contains("avro")
         }
       }),
-      ScoverageSbtPlugin.ScoverageKeys.coverageHighlighting := {
+      ScoverageKeys.coverageHighlighting := {
         if (scalaBinaryVersion.value == "2.10") false
         else true
       },

--- a/project/build.properties
+++ b/project/build.properties
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-sbt.version=0.13.9
+sbt.version=0.13.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,12 +6,9 @@ resolvers += "Spark Package Main Repo" at "https://dl.bintray.com/spark-packages
 
 addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.2")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.1.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 
-// Workaround for https://github.com/scalastyle/scalastyle/pull/157
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.7.0" excludeAll(
-  ExclusionRule(organization = "com.danieltrinh")))
-libraryDependencies += "org.scalariform" %% "scalariform" % "0.1.7"
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
 
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
 


### PR DESCRIPTION
This PR makes several small changes to our test infra, including updating SBT and plugin versions, using a more modern Travis artifact caching strategy, and reducing the SBT heap size in order to avoid failed builds due to the Travis OOM killer.