### PR TITLE
Update RedshiftJDBCWrapper.scala

### DIFF
--- a/src/main/scala/com/databricks/spark/redshift/RedshiftJDBCWrapper.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftJDBCWrapper.scala
@@ -301,7 +301,7 @@ private[redshift] class JDBCWrapper {
     val answer = sqlType match {
       // scalastyle:off
       case java.sql.Types.ARRAY         => null
-      case java.sql.Types.BIGINT        => if (signed) { LongType } else { DecimalType(20,0) }
+      case java.sql.Types.BIGINT        => LongType
       case java.sql.Types.BINARY        => BinaryType
       case java.sql.Types.BIT           => BooleanType // @see JdbcDialect for quirks
       case java.sql.Types.BLOB          => BinaryType


### PR DESCRIPTION
java.sql.Types.BIGINT => LongType in all cases for Redshift.
Redshift has no unsigned BigInt, and thus BigInt maps to Long without loss of resolution.
See issue #310 