### PR TITLE
Added support for S3 Client Side Encryption (S3 CSE)

### DIFF
--- a/src/main/scala/com/databricks/spark/redshift/Parameters.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Parameters.scala
@@ -35,6 +35,7 @@ private[redshift] object Parameters {
     "tempformat" -> "AVRO",
     "csvnullstring" -> "@NULL@",
     "overwrite" -> "false",
+    "encryption" -> "false",
     "diststyle" -> "EVEN",
     "usestagingtable" -> "true",
     "preactions" -> ";",
@@ -158,6 +159,13 @@ private[redshift] object Parameters {
         password <- parameters.get("password")
       ) yield (user, password)
     }
+
+    /**
+     *  S3 Client Side Encryption will be enabled if encryption option is set
+     *  to true. Master symmetric key is taken from hadoop configuration
+     *  property spark-redshift.master-sym-key
+     */
+    def encryption: Boolean = parameters("encryption").toBoolean
 
     /**
      * A JDBC URL, of the format:

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftEncryptionMaterialsProvider.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftEncryptionMaterialsProvider.scala
@@ -1,0 +1,67 @@
+package com.databricks.spark.redshift
+
+import java.util
+import javax.crypto.SecretKey
+import javax.crypto.spec.SecretKeySpec
+
+import com.amazonaws.services.s3.model.{EncryptionMaterials, EncryptionMaterialsProvider}
+import com.amazonaws.util.Base64
+import org.apache.hadoop.conf.{Configurable, Configuration}
+
+
+/**
+  * This class provides encryption materials to be used by spark-redshfit
+  * library. It gets the master symmetric key from hadoop configuration,
+  * converts it into EncryptionMaterials and returns them.
+  */
+object RedshiftEncryptionMaterialsProvider {
+    /**
+      * Encryption algorithm used for by Redshift.
+      */
+    private val ENCRYPTION_ALGORITHM: String = "AES"
+    /**
+      * This is the hadoop configuration property name that contains
+      * redshift master symmetric key.
+      */
+    private val SPARK_REDSHIFT_MASTER_SYM_KEY: String = "spark-redshift.master-sym-key"
+}
+
+class RedshiftEncryptionMaterialsProvider
+    extends EncryptionMaterialsProvider
+    with Configurable {
+    /**
+      * The hadoop configuration.
+      */
+    private var conf: Configuration = null
+
+    def setConf(conf: Configuration) {
+        this.conf = conf
+    }
+
+    def getConf: Configuration = {
+        return this.conf
+    }
+
+    def refresh {
+    }
+
+    def getEncryptionMaterials(materialsDescription: Map[String, String]):
+    EncryptionMaterials = {
+        return getEncryptionMaterials
+    }
+
+    override def getEncryptionMaterials(
+        materialsDescription: util.Map[String, String]):
+    EncryptionMaterials = getEncryptionMaterials
+
+    override def getEncryptionMaterials: EncryptionMaterials = {
+        val masterKey: SecretKey =
+            new SecretKeySpec(
+                Base64.decode(
+                    conf.get(
+                        RedshiftEncryptionMaterialsProvider.
+                            SPARK_REDSHIFT_MASTER_SYM_KEY)),
+                RedshiftEncryptionMaterialsProvider.ENCRYPTION_ALGORITHM)
+        return new EncryptionMaterials(masterKey)
+    }
+}


### PR DESCRIPTION
This commit adds S3 Client Side Encryption support to spark-redshfit library that allows
full end-to-end data encryption over network for read/write operations.