### PR TITLE
add 'create_table_if_not_exist' params

### DIFF
--- a/src/main/scala/com/databricks/spark/redshift/Parameters.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Parameters.scala
@@ -38,7 +38,8 @@ private[redshift] object Parameters {
     "diststyle" -> "EVEN",
     "usestagingtable" -> "true",
     "preactions" -> ";",
-    "postactions" -> ";"
+    "postactions" -> ";",
+    "create_table_if_not_exist" -> "true"
   )
 
   val VALID_TEMP_FORMATS = Set("AVRO", "CSV", "CSV GZIP")
@@ -285,5 +286,13 @@ private[redshift] object Parameters {
           new BasicSessionCredentials(accessKey, secretAccessKey, sessionToken))
       }
     }
+
+
+    /**
+      * If true then this library will automatically discover the credentials that Spark is
+      * using to connect to S3 and will forward those credentials to Redshift over JDBC.
+      */
+    def createTableIfNotExist: Boolean = parameters("create_table_if_not_exist").toBoolean
+
   }
 }

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
@@ -124,10 +124,12 @@ private[redshift] class RedshiftWriter(
       creds: AWSCredentialsProvider,
       manifestUrl: Option[String]): Unit = {
 
-    // If the table doesn't exist, we need to create it first, using JDBC to infer column types
-    val createStatement = createTableSql(data, params)
-    log.info(createStatement)
-    jdbcWrapper.executeInterruptibly(conn.prepareStatement(createStatement))
+    if (params.createTableIfNotExist) {
+      // If the table doesn't exist, we need to create it first, using JDBC to infer column types
+      val createStatement = createTableSql(data, params)
+      log.info(createStatement)
+      jdbcWrapper.executeInterruptibly(conn.prepareStatement(createStatement))
+    }
 
     val preActions = commentActions(params.description, data.schema) ++ params.preActions
 


### PR DESCRIPTION
This is useful when merge operation.

1. create temp table A  (like schema.A)    -> run by preactions
2. load into table A ( dbtable = A )
3. update/insert     -> run by postactions

Above scenario, table A(=dbtable)  should not be created  