### PR TITLE
Update bucket lifecycle check

### DIFF
--- a/project/SparkRedshiftBuild.scala
+++ b/project/SparkRedshiftBuild.scala
@@ -51,7 +51,7 @@ object SparkRedshiftBuild extends Build {
       testSparkVersion := sys.props.get("spark.testVersion").getOrElse(sparkVersion.value),
       testSparkAvroVersion := sys.props.get("sparkAvro.testVersion").getOrElse("3.0.0"),
       testHadoopVersion := sys.props.get("hadoop.testVersion").getOrElse("2.2.0"),
-      testAWSJavaSDKVersion := sys.props.get("aws.testVersion").getOrElse("1.10.22"),
+      testAWSJavaSDKVersion := sys.props.get("aws.testVersion").getOrElse("1.11.166"),
       spName := "databricks/spark-redshift",
       sparkComponents ++= Seq("sql", "hive"),
       spIgnoreProvided := true,


### PR DESCRIPTION
`getPrefix` method on `Rule` [got deprecated](https://github.com/aws/aws-sdk-java/blob/355424771b951ef0066b19c3eab4b4356e270cf4/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/BucketLifecycleConfiguration.java#L145-L153)
It seems that reponse on the wire was also changed so this method no
longer returns the prefix even on older versions of AWS SDK (as the one
used by this project).

I've bumped the AWS SDK dependencies version and implemented the check
using new visitor pattern. I am not sure it is the nicest scala code,
but I think it works. Tests stil pass.

I believe this fixes #346.