### PR TITLE
Providing testing capabilities to outside packages

### DIFF
--- a/src/main/scala/com/databricks/spark/redshift/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/redshift/DefaultSource.scala
@@ -41,6 +41,11 @@ class DefaultSource(
   def this() = this(DefaultJDBCWrapper, awsCredentials => new AmazonS3Client(awsCredentials))
 
   /**
+   * Constructor to provide a custom S3 client factory
+   */
+  def this(s3ClientFactory: AWSCredentialsProvider => AmazonS3Client) = this(DefaultJDBCWrapper, s3ClientFactory)
+
+  /**
    * Create a new RedshiftRelation instance using parameters from Spark SQL DDL. Resolves the schema
    * using JDBC connection over provided URL, which must contain credentials.
    */

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
@@ -55,12 +55,12 @@ private[redshift] case class RedshiftRelation(
   }
 
   private val tableNameOrSubquery =
-    params.query.map(q => s"($q)").orElse(params.table.map(_.toString)).get
+    params.query.map(q => s"($q) AS q").orElse(params.table.map(_.toString)).get
 
   override lazy val schema: StructType = {
     userSchema.getOrElse {
       val tableNameOrSubquery =
-        params.query.map(q => s"($q)").orElse(params.table.map(_.toString)).get
+        params.query.map(q => s"($q) AS q").orElse(params.table.map(_.toString)).get
       val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl, params.credentials)
       try {
         jdbcWrapper.resolveTable(conn, tableNameOrSubquery)

--- a/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
@@ -181,7 +181,7 @@ class RedshiftSourceSuite
         |UNLOAD \('SELECT "testbyte", "testbool" FROM
         |  \(select testbyte, testbool
         |    from test_table
-        |    where teststring = \\'\\\\\\\\Unicode\\'\\'s樂趣\\'\) '\)
+        |    where teststring = \\'\\\\\\\\Unicode\\'\\'s樂趣\\'\) AS q '\)
       """.stripMargin.lines.map(_.trim).mkString(" ").trim.r
     val query =
       """select testbyte, testbool from test_table where teststring = '\\Unicode''s樂趣'"""
@@ -196,7 +196,7 @@ class RedshiftSourceSuite
     {
       val params = defaultParams + ("dbtable" -> s"($query)")
       val mockRedshift =
-        new MockRedshift(defaultParams("url"), Map(params("dbtable") -> querySchema))
+        new MockRedshift(defaultParams("url"), Map(s"${params("dbtable")} AS q" -> querySchema))
       val relation = new DefaultSource(
         mockRedshift.jdbcWrapper, _ => mockS3Client).createRelation(testSqlContext, params)
       assert(testSqlContext.baseRelationToDataFrame(relation).collect() === expectedValues)
@@ -207,7 +207,7 @@ class RedshiftSourceSuite
     // Test with query parameter
     {
       val params = defaultParams - "dbtable" + ("query" -> query)
-      val mockRedshift = new MockRedshift(defaultParams("url"), Map(s"($query)" -> querySchema))
+      val mockRedshift = new MockRedshift(defaultParams("url"), Map(s"($query) AS q" -> querySchema))
       val relation = new DefaultSource(
         mockRedshift.jdbcWrapper, _ => mockS3Client).createRelation(testSqlContext, params)
       assert(testSqlContext.baseRelationToDataFrame(relation).collect() === expectedValues)


### PR DESCRIPTION
The testing methods used inside `spark-redshift` are unfortunately all marked private and can't be used from the outside. We were looking for a way to run our tests against local mocks instead of the real online services. We got it working but had to do few minor adjustments to `spark-redshift`. Let me know if we could integrate these into the official version.
Our changes are:
1. We need an ability to provide a custom S3 client factory to `spark-redshift`, so we added an extra constructor to `DefaultSource`. The current constructor also requires a `JDBCWrapper`, which is marked private and therefore doesn't seem to be able to be passed in from the outside.
2. We're redirecting the Redshift queries to a local PostgreSQL instance (with a small compatiblity layer [redshift-fake-driver](https://github.com/opt-tech/redshift-fake-driver)). PostgreSQL unfortunately requires all subqueries to have an alias, which we added to the unload query generation.

Let me know what you think and if this could merged in.
