### PR TITLE
Enabling CSE encryption for COPY command

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,7 +428,11 @@ The following describes how each connection can be authenticated:
     To use this capability, you should configure your Hadoop S3 FileSystem to use encryption by
     setting the appropriate configuration properties (which will vary depending on whether you
     are using `s3a`, `s3n`, EMRFS, etc.).
+    
     Note that the `MANIFEST` file (a list of all files written) will not be encrypted.
+    
+    To use CSE with S3 during COPY, generate your own encryption key, and pass it to the writer using
+    ```.option("extracopyoptions", s"encrypted master_symmetric_key '$encodedSymmetricKey'")```
 
 
 ### Parameters

--- a/src/main/scala/com/databricks/spark/redshift/AWSCredentialsUtils.scala
+++ b/src/main/scala/com/databricks/spark/redshift/AWSCredentialsUtils.scala
@@ -28,6 +28,7 @@ private[redshift] object AWSCredentialsUtils {
   /**
     * Generates a credentials string for use in Redshift COPY and UNLOAD statements.
     * Favors a configured `aws_iam_role` if available in the parameters.
+    * http://docs.aws.amazon.com/redshift/latest/dg/copy-parameters-authorization.html
     */
   def getRedshiftCredentialsString(
       params: MergedParameters,
@@ -36,15 +37,14 @@ private[redshift] object AWSCredentialsUtils {
     def awsCredsToString(credentials: AWSCredentials): String = {
       credentials match {
         case creds: AWSSessionCredentials =>
-          s"aws_access_key_id=${creds.getAWSAccessKeyId};" +
-            s"aws_secret_access_key=${creds.getAWSSecretKey};token=${creds.getSessionToken}"
+          s"access_key_id '${creds.getAWSAccessKeyId}' secret_access_key '${creds.getAWSSecretKey}' " +
+            s"session_token '${creds.getSessionToken}'"
         case creds =>
-          s"aws_access_key_id=${creds.getAWSAccessKeyId};" +
-            s"aws_secret_access_key=${creds.getAWSSecretKey}"
+          s"access_key_id '${creds.getAWSAccessKeyId}' secret_access_key '${creds.getAWSSecretKey}'"
       }
     }
     if (params.iamRole.isDefined) {
-      s"aws_iam_role=${params.iamRole.get}"
+      s"iam_role '${params.iamRole.get}'"
     } else if (params.temporaryAWSCredentials.isDefined) {
       awsCredsToString(params.temporaryAWSCredentials.get.getCredentials)
     } else if (params.forwardSparkS3Credentials) {

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftRelation.scala
@@ -193,7 +193,7 @@ private[redshift] case class RedshiftRelation(
     // the credentials passed via `credsString`.
     val fixedUrl = Utils.fixS3Url(Utils.removeCredentialsFromURI(new URI(tempDir)).toString)
 
-    s"UNLOAD ('$query') TO '$fixedUrl' WITH CREDENTIALS '$credsString' ESCAPE MANIFEST"
+    s"UNLOAD ('$query') TO '$fixedUrl' $credsString ESCAPE MANIFEST"
   }
 
   private def pruneSchema(schema: StructType, columns: Array[String]): StructType = {

--- a/src/test/scala/com/databricks/spark/redshift/AWSCredentialsUtilsSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/AWSCredentialsUtilsSuite.scala
@@ -42,7 +42,7 @@ class AWSCredentialsUtilsSuite extends FunSuite {
     val params =
       Parameters.mergeParameters(baseParams ++ Map("forward_spark_s3_credentials" -> "true"))
     assert(AWSCredentialsUtils.getRedshiftCredentialsString(params, creds) ===
-      "aws_access_key_id=ACCESSKEYID;aws_secret_access_key=SECRET/KEY/WITH/SLASHES")
+      "access_key_id 'ACCESSKEYID' secret_access_key 'SECRET/KEY/WITH/SLASHES'")
   }
 
   test("credentialsString with STS temporary keys") {
@@ -51,7 +51,7 @@ class AWSCredentialsUtilsSuite extends FunSuite {
       "temporary_aws_secret_access_key" -> "SECRET/KEY",
       "temporary_aws_session_token" -> "SESSION/Token"))
     assert(AWSCredentialsUtils.getRedshiftCredentialsString(params, null) ===
-      "aws_access_key_id=ACCESSKEYID;aws_secret_access_key=SECRET/KEY;token=SESSION/Token")
+      "access_key_id 'ACCESSKEYID' secret_access_key 'SECRET/KEY' session_token 'SESSION/Token'")
   }
 
   test("Configured IAM roles should take precedence") {
@@ -59,7 +59,7 @@ class AWSCredentialsUtilsSuite extends FunSuite {
     val iamRole = "arn:aws:iam::123456789000:role/redshift_iam_role"
     val params = Parameters.mergeParameters(baseParams ++ Map("aws_iam_role" -> iamRole))
     assert(AWSCredentialsUtils.getRedshiftCredentialsString(params, null) ===
-      s"aws_iam_role=$iamRole")
+      s"iam_role '$iamRole'")
   }
 
   test("AWSCredentials.load() STS temporary keys should take precedence") {

--- a/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
+++ b/src/test/scala/com/databricks/spark/redshift/RedshiftSourceSuite.scala
@@ -159,7 +159,7 @@ class RedshiftSourceSuite
       "\"testtimestamp\" " +
       "FROM \"PUBLIC\".\"test_table\" '\\) " +
       "TO '.*' " +
-      "WITH CREDENTIALS 'aws_access_key_id=test1;aws_secret_access_key=test2' " +
+      "access_key_id 'test1' secret_access_key 'test2' " +
       "ESCAPE").r
     val mockRedshift = new MockRedshift(
       defaultParams("url"),
@@ -230,7 +230,7 @@ class RedshiftSourceSuite
     val expectedQuery = (
       "UNLOAD \\('SELECT \"testbyte\", \"testbool\" FROM \"PUBLIC\".\"test_table\" '\\) " +
       "TO '.*' " +
-      "WITH CREDENTIALS 'aws_access_key_id=test1;aws_secret_access_key=test2' " +
+      "access_key_id 'test1' secret_access_key 'test2' " +
       "ESCAPE").r
     val mockRedshift =
       new MockRedshift(defaultParams("url"), Map("test_table" -> TestUtils.testSchema))
@@ -270,7 +270,7 @@ class RedshiftSourceSuite
         "AND \"testfloat\" >= 1.0 " +
         "AND \"testint\" <= 43'\\) " +
       "TO '.*' " +
-      "WITH CREDENTIALS 'aws_access_key_id=test1;aws_secret_access_key=test2' " +
+      "access_key_id 'test1' secret_access_key 'test2' " +
       "ESCAPE").r
     // scalastyle:on
     val mockRedshift = new MockRedshift(


### PR DESCRIPTION
With these changes one can write encrypted data to S3 using client side encryption, with a custom symmetric master key, and then use spark-redshift to ingest the data. I have sensitive data ingesting into Redshift and can't use S3-SSE for my data.

The main change was to switch away from WITH CREDENTIALS syntax and explicitly pass iam_role, access_key, etc. parameters so that the end-user can use the "extracopyoptions" to supply their symmetric key.

Usage:
```    
sparkSession.table(name)
      .write
      .format("com.databricks.spark.redshift")
      .option("url", redshiftUrl)
      .option("dbtable", options(REDSHIFT_TABLE_NAME))
      // If the table does not exist, then it will be created. If it exists, then data will be appended to it
      .mode(SaveMode.Append)
      .option("temporary_aws_access_key_id", options(AWS_ACCESS_ID))
      .option("temporary_aws_secret_access_key", options(AWS_SECRET_KEY))
      .option("temporary_aws_session_token", options(AWS_SESSION_TOKEN))
      .option("tempdir", options(REDSHIFT_TEMPORARY_S3_LOCATION))
      // we must encrypt the data when writing to S3, and we have to pass
      // the symmetric encryption key to Redshift so that it can decrypt the data.
      // See http://docs.aws.amazon.com/redshift/latest/dg/c_loading-encrypted-files.html
      .option("extracopyoptions", s"encrypted master_symmetric_key '$encodedSymmetricKey'")
      .save()
```