### PR TITLE
Add support for writetimeout

### DIFF
--- a/src/main/scala/com/databricks/spark/redshift/Parameters.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Parameters.scala
@@ -18,6 +18,8 @@ package com.databricks.spark.redshift
 
 import com.amazonaws.auth.{AWSCredentialsProvider, BasicSessionCredentials}
 
+import scala.util.Try
+
 /**
  * All user-specifiable parameters for spark-redshift, along with their validation rules and
  * defaults.
@@ -285,5 +287,11 @@ private[redshift] object Parameters {
           new BasicSessionCredentials(accessKey, secretAccessKey, sessionToken))
       }
     }
+
+    /**
+      * Timeout (in milliseconds) between writing temp files in S3 and calling
+      * upon Redshift to COPY.
+      */
+    def writeTimeout: Try[Int] = Try(parameters.get("writetimeout").get.toInt)
   }
 }

--- a/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
+++ b/src/main/scala/com/databricks/spark/redshift/RedshiftWriter.scala
@@ -395,6 +395,11 @@ private[redshift] class RedshiftWriter(
       tempDir = params.createPerQueryTempDir(),
       tempFormat = params.tempFormat,
       nullString = params.nullString)
+
+    if (params.writeTimeout.isSuccess) {
+      Thread.sleep(params.writeTimeout.get)
+    }
+
     val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl, params.credentials)
     conn.setAutoCommit(false)
     try {


### PR DESCRIPTION
Added support to specify timeout between writing temp files in S3 and calling upon Redshift to COPY. This fixes the issue caused by the eventual consistency of S3 `S3ServiceException:The specified key does not exist.,Status 404,Error NoSuchKey` when  trying to write a DataFrame to Redshift. The issue is described in more details here: https://github.com/databricks/spark-redshift/issues/136 